### PR TITLE
Mark PreProcessor as public

### DIFF
--- a/src/RhinoInside.Revit/Revit.FailuresPreprocessor.cs
+++ b/src/RhinoInside.Revit/Revit.FailuresPreprocessor.cs
@@ -12,7 +12,7 @@ namespace RhinoInside.Revit
 {
   public partial class Revit
   {
-    class FailuresPreprocessor : IFailuresPreprocessor
+    public class FailuresPreprocessor : IFailuresPreprocessor
     {
       public FailureProcessingResult PreprocessFailures(FailuresAccessor failuresAccessor)
       {


### PR DESCRIPTION
Trying to use FailuresPreprocessor as part of a C# ScriptInstance, but it is not a public class.