### PR TITLE
Use build date env var for product info template if present

### DIFF
--- a/src/RhinoInside.Revit.GH/Properties/ProductInfo.tt
+++ b/src/RhinoInside.Revit.GH/Properties/ProductInfo.tt
@@ -23,7 +23,9 @@ using (var reader = new StreamReader(this.Host.ResolvePath($"../../ProductInfo.x
   Major = product.MajorVersion;
   Minor = product.MinorVersion;
 
-  var now = DateTime.Now;
+  var buildDate = Environment.GetEnvironmentVariable("BuildDate");
+  var now = !string.IsNullOrWhiteSpace(buildDate) ? DateTime.Parse(buildDate) :
+            DateTime.Now;
   var days = now.Date - new DateTime(2000, 1, 1);
 
   Build = product.BuildVersion.HasValue ? product.BuildVersion.Value :

--- a/src/RhinoInside.Revit.Native/version.tt
+++ b/src/RhinoInside.Revit.Native/version.tt
@@ -23,7 +23,9 @@ using (var reader = new StreamReader(this.Host.ResolvePath($"../ProductInfo.xml"
   Major = product.MajorVersion;
   Minor = product.MinorVersion;
 
-  var now = DateTime.Now;
+  var buildDate = Environment.GetEnvironmentVariable("BuildDate");
+  var now = !string.IsNullOrWhiteSpace(buildDate) ? DateTime.Parse(buildDate) :
+            DateTime.Now;
   var days = now.Date - new DateTime(2000, 1, 1);
 
   Build = product.BuildVersion.HasValue ? product.BuildVersion.Value :

--- a/src/RhinoInside.Revit/Properties/ProductInfo.tt
+++ b/src/RhinoInside.Revit/Properties/ProductInfo.tt
@@ -23,7 +23,9 @@ using (var reader = new StreamReader(this.Host.ResolvePath($"../../ProductInfo.x
   Major = product.MajorVersion;
   Minor = product.MinorVersion;
 
-  var now = DateTime.Now;
+  var buildDate = Environment.GetEnvironmentVariable("BuildDate");
+  var now = !string.IsNullOrWhiteSpace(buildDate) ? DateTime.Parse(buildDate) :
+            DateTime.Now;
   var days = now.Date - new DateTime(2000, 1, 1);
 
   Build = product.BuildVersion.HasValue ? product.BuildVersion.Value :


### PR DESCRIPTION
To give all assemblies the same version number, the `BuildDate` environment variable should be set by the CI build before compiling the project