### PR TITLE
1.0-RC1

### DIFF
--- a/src/RhinoInside.Revit.GH/Components/Component.cs
+++ b/src/RhinoInside.Revit.GH/Components/Component.cs
@@ -206,7 +206,10 @@ namespace RhinoInside.Revit.GH.Components
       }
       catch (Exceptions.RuntimeArgumentException e)
       {
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, e.Message);
+        if (AbortOnUnhandledException)
+          unhandledException = e;
+
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.Message);
       }
       catch (Exceptions.RuntimeWarningException e)
       {

--- a/src/RhinoInside.Revit.GH/Components/Document/ProjectLocation.cs
+++ b/src/RhinoInside.Revit.GH/Components/Document/ProjectLocation.cs
@@ -63,7 +63,7 @@ namespace RhinoInside.Revit.GH.Components
       Params.TrySetData(DA, "Shared Site", () => new Types.ProjectLocation(doc.ActiveProjectLocation));
       Params.TrySetData(DA, "Survey Point", () => new Types.BasePoint(BasePointExtension.GetSurveyPoint(doc)));
       Params.TrySetData(DA, "Project Base Point", () => new Types.BasePoint(BasePointExtension.GetProjectBasePoint(doc)));
-      Params.TrySetData(DA, "Internal Origin", () => new Types.BasePoint(BasePointExtension.GetInternalOriginPoint(doc)));
+      Params.TrySetData(DA, "Internal Origin", () => new Types.InternalOrigin(InternalOriginExtension.GetInternalOriginPoint(doc)));
     }
   }
 }

--- a/src/RhinoInside.Revit.GH/Components/Element/Parameters.cs
+++ b/src/RhinoInside.Revit.GH/Components/Element/Parameters.cs
@@ -396,11 +396,7 @@ namespace RhinoInside.Revit.GH.Components.Element
 
       DA.SetData("Element", element);
 
-      Params.TrySetData(DA, "Parameter", () =>
-        key.IsReferencedData ?
-        key :
-        new Types.ParameterKey(element.Document, parameter.Definition as DB.InternalDefinition));
-
+      Params.TrySetData(DA, "Parameter", () => new Types.ParameterKey(element.Document, parameter.Definition as DB.InternalDefinition));
       Params.TrySetData(DA, "Value", () => parameter.AsGoo());
     }
   }

--- a/src/RhinoInside.Revit.GH/Components/Element/ProjectLocation/Query.cs
+++ b/src/RhinoInside.Revit.GH/Components/Element/ProjectLocation/Query.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Windows.Forms;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Parameters;
 using DB = Autodesk.Revit.DB;
@@ -12,6 +13,22 @@ namespace RhinoInside.Revit.GH.Components.Site
     public override GH_Exposure Exposure => GH_Exposure.primary;
     protected override string IconTag => "⌖";
     protected override DB.ElementFilter ElementFilter => new DB.ElementClassFilter(typeof(DB.ProjectLocation));
+
+    #region UI
+    protected override void AppendAdditionalComponentMenuItems(ToolStripDropDown menu)
+    {
+      base.AppendAdditionalComponentMenuItems(menu);
+
+      var activeApp = Revit.ActiveUIApplication;
+      var commandId = Autodesk.Revit.UI.RevitCommandId.LookupPostableCommandId(Autodesk.Revit.UI.PostableCommand.Location);
+      Menu_AppendItem
+      (
+        menu, $"Open Location…",
+        (sender, arg) => External.UI.EditScope.PostCommand(activeApp, commandId),
+        activeApp.CanPostCommand(commandId), false
+      );
+    }
+    #endregion
 
     public QueryProjectLocations()
     : base

--- a/src/RhinoInside.Revit.GH/Components/Element/View/Identity.cs
+++ b/src/RhinoInside.Revit.GH/Components/Element/View/Identity.cs
@@ -47,9 +47,10 @@ namespace RhinoInside.Revit.GH.Components
       else
         DA.SetData("Discipline", null);
 
-      DA.SetData("Family", (view.Document.GetElement(view.GetTypeId()) as DB.ViewFamilyType).ViewFamily);
+      var type = view.Document.GetElement(view.GetTypeId());
+      DA.SetData("Family", (type as DB.ViewFamilyType)?.ViewFamily);
       DA.SetData("Name", view.Name);
-      DA.SetData("Template", view.Document.GetElement(view.ViewTemplateId) as DB.View);
+      DA.SetData("Template", new Types.View(view.Document, view.ViewTemplateId));
       DA.SetData("Is Template", view.IsTemplate);
       DA.SetData("Is Assembly", view.IsAssemblyView);
       DA.SetData("Is Printable", view.CanBePrinted);

--- a/src/RhinoInside.Revit.GH/Components/ElementType/SiteLocation/Identity.cs
+++ b/src/RhinoInside.Revit.GH/Components/ElementType/SiteLocation/Identity.cs
@@ -28,15 +28,15 @@ namespace RhinoInside.Revit.GH.Components.Site
     {
       ParamDefinition.Create<Parameters.ElementType>("Site Location", "SL"),
       ParamDefinition.Create<Param_String>("Place Name", "PN", optional: true, relevance: ParamRelevance.Primary),
-      ParamDefinition.Create<Param_Number>("Time Zone", "TZ", optional: true, relevance: ParamRelevance.Primary),
+      ParamDefinition.Create<Param_Number>("Time Zone", "TZ", "Hours ranging from -12 to +12. 0 represents GMT.", optional: true, relevance: ParamRelevance.Primary),
       new ParamDefinition
       (
-        new Param_Number() { Name = "Latitude", NickName = "LAT", Optional = true, AngleParameter = true, UseDegrees = true },
+        new Param_Angle() { Name = "Latitude", NickName = "LAT", Optional = true, AngleParameter = true, UseDegrees = true },
         ParamRelevance.Primary
       ),
       new ParamDefinition
       (
-        new Param_Number() { Name = "Longitude", NickName = "LON", Optional = true, AngleParameter = true, UseDegrees = true },
+        new Param_Angle() { Name = "Longitude", NickName = "LON", Optional = true, AngleParameter = true, UseDegrees = true },
         ParamRelevance.Primary
       ),
     };
@@ -51,12 +51,12 @@ namespace RhinoInside.Revit.GH.Components.Site
       ParamDefinition.Create<Param_Number>("Time Zone", "TZ", "The time-zone for the site", relevance: ParamRelevance.Primary),
       new ParamDefinition
       (
-        new Param_Number() { Name = "Latitude", NickName = "LAT", Description = "The latitude of the site location", AngleParameter = true, UseDegrees = true },
+        new Param_Angle() { Name = "Latitude", NickName = "LAT", Description = "The latitude of the site location", AngleParameter = true, UseDegrees = true },
         ParamRelevance.Primary
       ),
       new ParamDefinition
       (
-        new Param_Number() { Name = "Longitude", NickName = "LON", Description = "The longitude of the site location", AngleParameter = true, UseDegrees = true },
+        new Param_Angle() { Name = "Longitude", NickName = "LON", Description = "The longitude of the site location", AngleParameter = true, UseDegrees = true },
         ParamRelevance.Primary
       ),
     };
@@ -67,9 +67,9 @@ namespace RhinoInside.Revit.GH.Components.Site
 
       bool update = false;
       update |= Params.GetData(DA, "Place Name", out string placeName);
-      update |= Params.GetData(DA, "TimeZone", out double? timeZone);
+      update |= Params.GetData(DA, "Time Zone", out double? timeZone);
       update |= Params.GetData(DA, "Latitude", out double? latitude);
-      update |= Params.GetData(DA, "TimeZone", out double? longitude);
+      update |= Params.GetData(DA, "Longitude", out double? longitude);
 
       if (update)
       {
@@ -79,24 +79,37 @@ namespace RhinoInside.Revit.GH.Components.Site
         if (timeZone != null) location.Value.TimeZone = timeZone.Value;
         if (latitude != null)
         {
-          location.Value.Latitude = Params.Input<Param_Number>("Latitude").UseDegrees ?
-            ToRadians(latitude.Value) :
-            latitude.Value;
+          if (Params.Input<Param_Number>("Latitude").UseDegrees)
+          {
+            if (Math.Abs(latitude.Value) < 90.0)
+              location.Value.Latitude = ToRadians(latitude.Value);
+            else
+              throw new Exceptions.RuntimeArgumentException("Latitude", "Value is out of range. It must be between -90 and 90.");
+          }
+          else
+          {
+            if (Math.Abs(latitude.Value) < Math.PI / 2.0)
+              location.Value.Latitude = latitude.Value;
+            else
+              throw new Exceptions.RuntimeArgumentException("Latitude", "Value is out of range. It must be between -PI/2 and PI/2.");
+          }
         }
+
         if (longitude != null)
         {
           location.Value.Longitude = Params.Input<Param_Number>("Longitude").UseDegrees ?
-            ToRadians(longitude.Value) :
+            ToRadians(longitude.Value) % (2.0 * Math.PI) :
             longitude.Value;
         }
       }
 
+      Params.TrySetData(DA, "Site Location", () => location);
       Params.TrySetData(DA, "Place Name", () => location.Value.PlaceName);
       Params.TrySetData(DA, "Weather Station", () => location.Value.WeatherStationName);
       Params.TrySetData(DA, "Time Zone", () => location.Value.TimeZone);
       Params.TrySetData(DA, "Latitude", () => Params.Output<Param_Number>("Latitude").UseDegrees ? ToDegrees(location.Value.Latitude) : location.Value.Latitude);
       Params.TrySetData(DA, "Longitude", () => Params.Output<Param_Number>("Longitude").UseDegrees ? ToDegrees(location.Value.Longitude) : location.Value.Longitude);
-      Params.TrySetData(DA, "Elevation", () => location.Value.Elevation);
+      Params.TrySetData(DA, "Elevation", () => location.Value.Elevation * Revit.ModelUnits);
     }
   }
 }

--- a/src/RhinoInside.Revit.GH/Components/ElementType/SiteLocation/Query.cs
+++ b/src/RhinoInside.Revit.GH/Components/ElementType/SiteLocation/Query.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Windows.Forms;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Parameters;
 using DB = Autodesk.Revit.DB;
@@ -9,9 +10,25 @@ namespace RhinoInside.Revit.GH.Components.Site
   public class QuerySiteLocations : ElementCollectorComponent
   {
     public override Guid ComponentGuid => new Guid("9C352309-F20B-4C9B-AF46-3783D1106CDF");
-    public override GH_Exposure Exposure => GH_Exposure.primary;
+    public override GH_Exposure Exposure => GH_Exposure.primary | GH_Exposure.obscure;
     protected override string IconTag => "⌖";
     protected override DB.ElementFilter ElementFilter => new DB.ElementClassFilter(typeof(DB.SiteLocation));
+
+    #region UI
+    protected override void AppendAdditionalComponentMenuItems(ToolStripDropDown menu)
+    {
+      base.AppendAdditionalComponentMenuItems(menu);
+
+      var activeApp = Revit.ActiveUIApplication;
+      var commandId = Autodesk.Revit.UI.RevitCommandId.LookupPostableCommandId(Autodesk.Revit.UI.PostableCommand.Location);
+      Menu_AppendItem
+      (
+        menu, $"Open Location…",
+        (sender, arg) => External.UI.EditScope.PostCommand(activeApp, commandId),
+        activeApp.CanPostCommand(commandId), false
+      );
+    }
+    #endregion
 
     public QuerySiteLocations()
     : base

--- a/src/RhinoInside.Revit.GH/Components/ParameterElement/AddParameter.cs
+++ b/src/RhinoInside.Revit.GH/Components/ParameterElement/AddParameter.cs
@@ -116,6 +116,12 @@ namespace RhinoInside.Revit.GH.Components.ParameterElement
       if (!Params.GetData(DA, "Definition", out Types.ParameterKey key, x => x.IsValid)) return;
       if (!Params.GetData(DA, "Binding", out Types.ParameterBinding binding, x => x.IsValid && x.Value != DBX.ParameterBinding.Unknown)) return;
 
+      if (key.DataType is null)
+        throw new Exceptions.RuntimeErrorException($"Unknown data-type for parameter '{key.Name}'");
+
+      if (key.Id.TryGetBuiltInParameter(out var _))
+        throw new Exceptions.RuntimeWarningException($"Parameter '{key.Name}' is a BuiltIn parameter");
+
       // Previous Output
       Params.ReadTrackedElement(_Parameter_, doc.Value, out DB.ParameterElement parameter);
 

--- a/src/RhinoInside.Revit.GH/Components/ZuiComponent.cs
+++ b/src/RhinoInside.Revit.GH/Components/ZuiComponent.cs
@@ -373,7 +373,10 @@ namespace RhinoInside.Revit.GH.Components
               param.Optional = input.Param.Optional;
 
               if (input.Param is Param_Number input_number && param is Param_Number param_number)
+              {
                 param_number.AngleParameter = input_number.AngleParameter;
+                param_number.UseDegrees = input_number.UseDegrees;
+              }
             }
           }
 
@@ -394,8 +397,11 @@ namespace RhinoInside.Revit.GH.Components
               param.Access = output.Param.Access;
               param.Optional = output.Param.Optional;
 
-              if (output.Param is Param_Number input_number && param is Param_Number param_number)
-                param_number.AngleParameter = input_number.AngleParameter;
+              if (output.Param is Param_Number output_number && param is Param_Number param_number)
+              {
+                param_number.AngleParameter = output_number.AngleParameter;
+                param_number.UseDegrees = output_number.UseDegrees;
+              }
             }
           }
         }

--- a/src/RhinoInside.Revit.GH/Extensions/Grasshopper/Kernel/IGH_ParamExtension.cs
+++ b/src/RhinoInside.Revit.GH/Extensions/Grasshopper/Kernel/IGH_ParamExtension.cs
@@ -229,6 +229,12 @@ namespace Grasshopper.Kernel
         if (newParam.MutableNickName && CentralSettings.CanvasFullNames)
           newParam.NickName = newParam.Name;
 
+        if (newParam is Parameters.Param_Number newNumberParam)
+        {
+          newNumberParam.AngleParameter = ((Parameters.Param_Number) param).AngleParameter;
+          newNumberParam.UseDegrees = ((Parameters.Param_Number) param).UseDegrees;
+        }
+
         return newParam;
       }
       finally { param.Attributes = attributes; }

--- a/src/RhinoInside.Revit.GH/Extensions/Grasshopper/Kernel/Parameters/Param_Angle.cs
+++ b/src/RhinoInside.Revit.GH/Extensions/Grasshopper/Kernel/Parameters/Param_Angle.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Grasshopper.Kernel.Parameters
+{
+  public class Param_Angle : Param_Number
+  {
+    public override Guid ComponentGuid => new Guid("A909509E-6F5C-43E3-A26D-ABC86DB797B8");
+    public override GH_Exposure Exposure => GH_Exposure.hidden;
+
+    public Param_Angle()
+    {
+      Name = "Angle";
+      NickName = "Angle";
+      Description = "Contains a collection of angles values.";
+      Category = "Params";
+      SubCategory = "Primitive";
+      AngleParameter = true;
+    }
+  }
+}

--- a/src/RhinoInside.Revit.GH/Extensions/Grasshopper/Special/ValueSet.cs
+++ b/src/RhinoInside.Revit.GH/Extensions/Grasshopper/Special/ValueSet.cs
@@ -927,19 +927,6 @@ namespace Grasshopper.Special
 
                 return GH_ObjectResponse.Handled;
               }
-
-              if (canvas.Viewport.Zoom >= GH_Viewport.ZoomDefault * 0.8f /*&& Owner.DataType == GH_ParamData.remote*/)
-              {
-                if (ListBounds.Contains(canvasLocation))
-                {
-                  foreach (var item in Owner.ListItems)
-                    item.Selected = true;
-
-                  Owner.ResetPersistentData(Owner.ListItems.Select(x => x.Value), "Select all");
-
-                  return GH_ObjectResponse.Handled;
-                }
-              }
             }
           }
         }

--- a/src/RhinoInside.Revit.GH/Parameters/Input/BuiltInParameters.cs
+++ b/src/RhinoInside.Revit.GH/Parameters/Input/BuiltInParameters.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Grasshopper.Kernel;
 
 namespace RhinoInside.Revit.GH.Parameters.Input
@@ -30,7 +31,7 @@ namespace RhinoInside.Revit.GH.Parameters.Input
       if (SourceCount == 0)
       {
         m_data.Clear();
-        m_data.AppendRange(Types.ParameterId.EnumValues);
+        m_data.AppendRange(Types.ParameterId.EnumValues.Where(x => !string.IsNullOrEmpty(x.Value.Label)));
       }
 
       base.LoadVolatileData();

--- a/src/RhinoInside.Revit.GH/RhinoInside.Revit.GH.csproj
+++ b/src/RhinoInside.Revit.GH/RhinoInside.Revit.GH.csproj
@@ -358,6 +358,7 @@
     <Compile Include="Extensions\Grasshopper\Kernel\GH_Enum.cs" />
     <Compile Include="Extensions\Grasshopper\Kernel\IGH_ParamExtension.cs" />
     <Compile Include="Extensions\Grasshopper\Kernel\Data\IGH_StructureExtension.cs" />
+    <Compile Include="Extensions\Grasshopper\Kernel\Parameters\Param_Angle.cs" />
     <Compile Include="Extensions\Grasshopper\Kernel\Types\GH_ColorRGBA.cs" />
     <Compile Include="Extensions\Grasshopper\Kernel\Parameters\Param_ColorRGBA.cs" />
     <Compile Include="Extensions\Grasshopper\Special\ValueSet.cs" />

--- a/src/RhinoInside.Revit.GH/Types/BasePoint.cs
+++ b/src/RhinoInside.Revit.GH/Types/BasePoint.cs
@@ -13,6 +13,13 @@ namespace RhinoInside.Revit.GH.Types
     protected override Type ScriptVariableType => typeof(DB.BasePoint);
     public new DB.BasePoint Value => base.Value as DB.BasePoint;
 
+    protected override bool SetValue(DB.Element element) => IsValidElement(element) && base.SetValue(element);
+    public static new bool IsValidElement(DB.Element element)
+    {
+      return element is DB.BasePoint &&
+             element.Category.Id.IntegerValue != (int) DB.BuiltInCategory.OST_IOS_GeoSite;
+    }
+
     public BasePoint() { }
     public BasePoint(DB.Document doc, DB.ElementId id) : base(doc, id) { }
     public BasePoint(DB.BasePoint point) : base(point) { }
@@ -105,5 +112,122 @@ namespace RhinoInside.Revit.GH.Types
       }
     }
     #endregion
+  }
+}
+
+namespace RhinoInside.Revit.GH.Types
+{
+// TODO : Upgrade Revit 2021 nuget package to 2021.0.1 and change the if below to REVIT_2021
+#if REVIT_2022
+  using DBInternalOrigin = Autodesk.Revit.DB.InternalOrigin;
+#else
+  using DBInternalOrigin = Autodesk.Revit.DB.BasePoint;
+#endif
+
+  [Kernel.Attributes.Name("Internal Origin")]
+  public class InternalOrigin : GraphicalElement
+  {
+    protected override Type ScriptVariableType => typeof(DBInternalOrigin);
+    public new DBInternalOrigin Value => base.Value as DBInternalOrigin;
+
+    protected override bool SetValue(DB.Element element) => IsValidElement(element) && base.SetValue(element);
+    public static new bool IsValidElement(DB.Element element)
+    {
+      return element is DBInternalOrigin &&
+             element.Category.Id.IntegerValue == (int) DB.BuiltInCategory.OST_IOS_GeoSite;
+    }
+
+    public InternalOrigin() { }
+    public InternalOrigin(DB.Document doc, DB.ElementId id) : base(doc, id) { }
+    public InternalOrigin(DBInternalOrigin point) : base(point) { }
+
+    public override string DisplayName
+    {
+      get
+      {
+        if (Value is DBInternalOrigin point)
+          return point.Category.Name;
+
+        return base.DisplayName;
+      }
+    }
+
+#region IGH_PreviewData
+    public override BoundingBox ClippingBox
+    {
+      get
+      {
+        if (Value is DBInternalOrigin point)
+        {
+          return new BoundingBox
+          (
+            new Point3d[]
+            {
+              point.GetPosition().ToPoint3d(),
+              (point.GetPosition() - point.GetSharedPosition()).ToPoint3d()
+            }
+          );
+        }
+
+        return NaN.BoundingBox;
+      }
+    }
+
+    public override void DrawViewportWires(GH_PreviewWireArgs args)
+    {
+      if (Value is DBInternalOrigin point)
+      {
+        var location = Location;
+        point.Category.Id.TryGetBuiltInCategory(out var builtInCategory);
+        var pointStyle = default(Rhino.Display.PointStyle);
+        var angle = default(float);
+        var radius = 6.0f;
+        var secondarySize = 3.5f;
+        switch (builtInCategory)
+        {
+          case DB.BuiltInCategory.OST_IOS_GeoSite:
+            pointStyle = Rhino.Display.PointStyle.ActivePoint;
+            break;
+          case DB.BuiltInCategory.OST_ProjectBasePoint:
+            pointStyle = Rhino.Display.PointStyle.RoundActivePoint;
+            angle = (float) Rhino.RhinoMath.ToRadians(45);
+            break;
+          case DB.BuiltInCategory.OST_SharedBasePoint:
+            pointStyle = Rhino.Display.PointStyle.Triangle;
+            radius = 12.0f;
+            secondarySize = 7.0f;
+            break;
+        }
+
+        var strokeColor = (System.Drawing.Color) Rhino.Display.ColorRGBA.ApplyGamma(new Rhino.Display.ColorRGBA(args.Color), 2.0);
+        args.Pipeline.DrawPoint(location.Origin, pointStyle, strokeColor, args.Color, radius, 2.0f, secondarySize, angle, true, true);
+      }
+    }
+#endregion
+
+#region Properties
+    public override Plane Location
+    {
+      get
+      {
+        if (Value is DBInternalOrigin point)
+        {
+          var origin = point.GetPosition().ToPoint3d();
+          var axisX = Vector3d.XAxis;
+          var axisY = Vector3d.YAxis;
+
+          if (true /*point.IsShared*/)
+          {
+            point.Document.ActiveProjectLocation.GetLocation(out var _, out var basisX, out var basisY);
+            axisX = basisX.ToVector3d();
+            axisY = basisY.ToVector3d();
+          }
+          return new Plane(origin, axisX, axisY);
+        }
+
+        return base.Location;
+      }
+    }
+#endregion
   }
 }

--- a/src/RhinoInside.Revit.GH/Types/DocumentObject.cs
+++ b/src/RhinoInside.Revit.GH/Types/DocumentObject.cs
@@ -25,7 +25,14 @@ namespace RhinoInside.Revit.GH.Types
       Equals(Document, other.Document) && Equals(Value, other.Value);
     public override bool Equals(object obj) => (obj is DocumentObject id) ? Equals(id) : base.Equals(obj);
     public override int GetHashCode() => Document.GetHashCode() ^ Value.GetHashCode();
-    public override string ToString() => $"Revit {((IGH_Goo) this).TypeName} : {DisplayName}";
+    public override string ToString()
+    {
+      string Invalid = IsValid ? string.Empty : "Invalid ";
+      string TypeName = ((IGH_Goo) this).TypeName;
+      string InstanceName = DisplayName is string displayName ? $" : {displayName}" : string.Empty;
+
+      return Invalid + TypeName + InstanceName;
+    }
 
     object ICloneable.Clone() => MemberwiseClone();
     #endregion
@@ -130,8 +137,6 @@ namespace RhinoInside.Revit.GH.Types
     }
 
     public abstract string DisplayName { get; }
-
-    string IGH_Goo.ToString() => DisplayName ?? "<INVALID>";
   }
 
   /// <summary>

--- a/src/RhinoInside.Revit.GH/Types/Element.cs
+++ b/src/RhinoInside.Revit.GH/Types/Element.cs
@@ -57,6 +57,8 @@ namespace RhinoInside.Revit.GH.Types
         return value;
       }
     }
+
+    public override string DisplayName => Name ?? (IsReferencedData ? string.Empty : "<None>");
     #endregion
 
     #region ReferenceObject
@@ -125,7 +127,11 @@ namespace RhinoInside.Revit.GH.Types
 
     public static readonly Dictionary<Type, Func<DB.Element, Element>> ActivatorDictionary = new Dictionary<Type, Func<DB.Element, Element>>()
     {
+// TODO : Upgrade Revit 2021 nuget package to 2021.0.1 and change the if below to REVIT_2021
+#if REVIT_2022
+      { typeof(DB.InternalOrigin),          (element)=> new InternalOrigin        (element as DB.InternalOrigin)    },
       { typeof(DB.BasePoint),               (element)=> new BasePoint             (element as DB.BasePoint)         },
+#endif
       { typeof(DB.DesignOption),            (element)=> new DesignOption          (element as DB.DesignOption)      },
       { typeof(DB.Phase),                   (element)=> new Phase                 (element as DB.Phase)             },
       { typeof(DB.SelectionFilterElement),  (element)=> new SelectionFilterElement(element as DB.SelectionFilterElement)},
@@ -207,8 +213,14 @@ namespace RhinoInside.Revit.GH.Types
 
           return new InstanceElement(element);
         }
-
-        if (GeometricElement.IsValidElement(element))
+// TODO : Upgrade Revit 2021 nuget package to 2021.0.1 and change the if below to REVIT_2021
+#if !REVIT_2022
+        else if (InternalOrigin.IsValidElement(element))
+          return new InternalOrigin(element as DB.BasePoint);
+        else if (BasePoint.IsValidElement(element))
+          return new BasePoint(element as DB.BasePoint);
+#endif
+        else if (GeometricElement.IsValidElement(element))
           return new GeometricElement(element);
 
         return new GraphicalElement(element);
@@ -430,18 +442,7 @@ namespace RhinoInside.Revit.GH.Types
 
     public override IGH_GooProxy EmitProxy() => new Proxy(this);
 
-    public override string DisplayName
-    {
-      get
-      {
-        if (Name is string name && name != string.Empty)
-          return name;
-
-        return base.DisplayName;
-      }
-    }
-
-    #region Properties
+#region Properties
     public bool CanDelete => IsValid && DB.DocumentValidation.CanDeleteElement(Document, Id);
 
     public bool? Pinned
@@ -592,9 +593,9 @@ namespace RhinoInside.Revit.GH.Types
         }
       }
     }
-    #endregion
+#endregion
 
-    #region Identity Data
+#region Identity Data
     public virtual string Description
     {
       get => Value?.get_Parameter(DB.BuiltInParameter.ALL_MODEL_DESCRIPTION)?.AsString();
@@ -678,6 +679,6 @@ namespace RhinoInside.Revit.GH.Types
           Value?.get_Parameter(DB.BuiltInParameter.ALL_MODEL_MARK)?.Set(value);
       }
     }
-    #endregion
+#endregion
   }
 }

--- a/src/RhinoInside.Revit.GH/Types/ElementId.cs
+++ b/src/RhinoInside.Revit.GH/Types/ElementId.cs
@@ -37,35 +37,31 @@ namespace RhinoInside.Revit.GH.Types
 
     public override string ToString()
     {
-      var TypeName = ((IGH_Goo) this).TypeName;
+      var valid = IsValid;
+      string Invalid = Id == DB.ElementId.InvalidElementId ?
+        string.Empty :
+        IsReferencedData ?
+        (valid ? /*"Referenced "*/ "" : "Unresolved ") :
+        (valid ? string.Empty : "Invalid ");
+      string TypeName = ((IGH_Goo) this).TypeName;
+      string InstanceName = DisplayName ?? string.Empty;
 
       if (!IsReferencedData)
-        return DisplayName;
+        return $"{Invalid}{TypeName} : {InstanceName}";
 
-      var tip = IsValid ?
-      (
-        IsReferencedDataLoaded ?
-#if DEBUG
-        $"{DisplayName} : id {Id.IntegerValue}" :
-#else
-        DisplayName :
-#endif
-        $"Unresolved {TypeName} : {UniqueID}"
-      ) :
-      $"Invalid {TypeName}" + (Id is object ? $" : id {Id.IntegerValue}" : string.Empty);
+      string InstanceId = valid ? $" : id {Id.IntegerValue}" : $" : {UniqueID}";
+
       using (var Documents = Revit.ActiveDBApplication.Documents)
       {
-        return
-        (
-          Documents.Size > 1 ?
-          $"{tip} @ {Document?.GetFileName() ?? DocumentGUID.ToString()}" :
-          tip
-        );
+        if (Documents.Size > 1)
+          InstanceId = $"{InstanceId} @ {Document?.GetFileName() ?? DocumentGUID.ToString("B")}";
       }
-    }
-#endregion
 
-#region GH_ISerializable
+      return $"{Invalid}{TypeName} : {InstanceName}{InstanceId}";
+    }
+    #endregion
+
+    #region GH_ISerializable
     protected override bool Read(GH_IReader reader)
     {
       UnloadReferencedData();
@@ -91,10 +87,9 @@ namespace RhinoInside.Revit.GH.Types
 
       return true;
     }
-#endregion
+    #endregion
 
-#region IGH_Goo
-
+    #region IGH_Goo
     public override bool IsValid => base.IsValid && Id.IsValid();
     public override string IsValidWhyNot
     {
@@ -127,6 +122,7 @@ namespace RhinoInside.Revit.GH.Types
         target = (Q) (object) Id;
         return true;
       }
+
       if (typeof(Q).IsAssignableFrom(typeof(GH_Integer)))
       {
         target = (Q) (object) new GH_Integer(Id.IntegerValue);
@@ -258,9 +254,9 @@ namespace RhinoInside.Revit.GH.Types
     }
 
     public virtual IGH_GooProxy EmitProxy() => new Proxy(this);
-#endregion
+    #endregion
 
-#region DocumentObject
+    #region DocumentObject
     public override object Value
     {
       get
@@ -272,9 +268,9 @@ namespace RhinoInside.Revit.GH.Types
       }
       protected set => base.Value = value;
     }
-#endregion
+    #endregion
 
-#region IGH_ReferencedData
+    #region IGH_ReferencedData
     public bool IsReferencedData => DocumentGUID != Guid.Empty;
     public abstract bool IsReferencedDataLoaded { get; }
 
@@ -287,16 +283,16 @@ namespace RhinoInside.Revit.GH.Types
       if (IsReferencedData)
         Document = default;
     }
-#endregion
+    #endregion
 
-#region IGH_ElementId
+    #region IGH_ElementId
     public abstract DB.Reference Reference { get; }
 
     public Guid DocumentGUID { get; protected set; } = Guid.Empty;
     public string UniqueID { get; protected set; } = string.Empty;
-#endregion
+    #endregion
 
-#region IGH_QuickCast
+    #region IGH_QuickCast
     GH_QuickCastType IGH_QuickCast.QC_Type => GH_QuickCastType.text;
     int IGH_QuickCast.QC_Hash() => FullUniqueId.Format(DocumentGUID, UniqueID).GetHashCode();
 
@@ -344,16 +340,16 @@ namespace RhinoInside.Revit.GH.Types
     Complex IGH_QuickCast.QC_Complex() => throw new InvalidCastException();
     Matrix IGH_QuickCast.QC_Matrix() => throw new InvalidCastException();
     Interval IGH_QuickCast.QC_Interval() => throw new InvalidCastException();
-#endregion
+    #endregion
 
     public ElementId() { }
 
     protected ElementId(DB.Document doc, object value) : base(doc, value) { }
 
-#region Properties
+    #region Properties
     public override string DisplayName => IsReferencedData ?
       Id is null ? "INVALID" : Id.IntegerValue.ToString() :
       "<None>";
-#endregion
+    #endregion
   }
 }

--- a/src/RhinoInside.Revit.GH/Types/ElementType.cs
+++ b/src/RhinoInside.Revit.GH/Types/ElementType.cs
@@ -26,39 +26,12 @@ namespace RhinoInside.Revit.GH.Types
     {
       get
       {
-        if (Value is DB.ElementType type)
-        {
-          var displayName = string.Empty;
-
-          if (type.Category is DB.Category category)
-            displayName += category.FullName();
-          displayName += " : ";
-
-          var familyName = type.GetFamilyName();
-          if (!string.IsNullOrEmpty(familyName))
-            displayName += familyName;
-          displayName += " : ";
-
-          displayName += type.Name;
-
-          if
-          (
-            type.get_Parameter(DB.BuiltInParameter.ALL_MODEL_TYPE_MARK) is DB.Parameter parameter &&
-            parameter.HasValue
-          )
-          {
-            var mark = parameter.AsString();
-            if (!string.IsNullOrEmpty(mark))
-              displayName += $" [{mark}]";
-          }
-
-          return displayName;
-        }
+        if (Value is DB.ElementType type && type.GetFamilyName() is string familyName && familyName.Length > 0)
+          return $"{familyName} : {Name}";
 
         return base.DisplayName;
       }
     }
-
 
     public string FamilyName => Value?.GetFamilyName();
 

--- a/src/RhinoInside.Revit.GH/Types/Enums.cs
+++ b/src/RhinoInside.Revit.GH/Types/Enums.cs
@@ -175,6 +175,38 @@ namespace RhinoInside.Revit.GH.Types
   public class ViewType : GH_Enum<DB.ViewType>
   {
     public override bool IsEmpty => Value == DB.ViewType.Undefined;
+    public ViewType() { }
+    public ViewType(DB.ViewType value) : base(value) { }
+    public static new ReadOnlyDictionary<int, string> NamedValues { get; } = new ReadOnlyDictionary<int, string>
+    (
+      new Dictionary<int, string>
+      {
+        { (int) DB.ViewType.FloorPlan,            "Floor Plan" },
+        { (int) DB.ViewType.CeilingPlan,          "Ceiling Plan" },
+        { (int) DB.ViewType.Elevation,            "Elevation" },
+        { (int) DB.ViewType.ThreeD,               "3D View" },
+        { (int) DB.ViewType.Schedule,             "Schedule" },
+        { (int) DB.ViewType.DrawingSheet,         "Sheet" },
+        { (int) DB.ViewType.ProjectBrowser,       "Project Browser" },
+        { (int) DB.ViewType.Report,               "Report" },
+        { (int) DB.ViewType.DraftingView,         "Drafting" },
+        { (int) DB.ViewType.Legend,               "Legend" },
+        { (int) DB.ViewType.SystemBrowser,        "System Browser" },
+        { (int) DB.ViewType.EngineeringPlan,      "Engineering Plan" },
+        { (int) DB.ViewType.AreaPlan,             "Area Plan" },
+        { (int) DB.ViewType.Section,              "Section" },
+        { (int) DB.ViewType.Detail,               "Detail" },
+        { (int) DB.ViewType.CostReport,           "Cost Report" },
+        { (int) DB.ViewType.LoadsReport,          "Loads Report" },
+        { (int) DB.ViewType.PresureLossReport,    "Presure Loss Report" },
+        { (int) DB.ViewType.ColumnSchedule,       "Column Schedule" },
+        { (int) DB.ViewType.PanelSchedule,        "Panel Schedule" },
+        { (int) DB.ViewType.Walkthrough,          "Walkthrough" },
+        { (int) DB.ViewType.Rendering,            "Rendering" },
+        { (int) DB.ViewType.SystemsAnalysisReport,"Systems Analysis Report" },
+        { (int) DB.ViewType.Internal,             "Internal" },
+      }
+    );
   }
 
   [

--- a/src/RhinoInside.Revit.GH/Types/Enums.cs
+++ b/src/RhinoInside.Revit.GH/Types/Enums.cs
@@ -203,7 +203,9 @@ namespace RhinoInside.Revit.GH.Types
         { (int) DB.ViewType.PanelSchedule,        "Panel Schedule" },
         { (int) DB.ViewType.Walkthrough,          "Walkthrough" },
         { (int) DB.ViewType.Rendering,            "Rendering" },
+#if REVIT_2020
         { (int) DB.ViewType.SystemsAnalysisReport,"Systems Analysis Report" },
+#endif
         { (int) DB.ViewType.Internal,             "Internal" },
       }
     );

--- a/src/RhinoInside.Revit.GH/Types/GeometricElement.cs
+++ b/src/RhinoInside.Revit.GH/Types/GeometricElement.cs
@@ -21,24 +21,6 @@ namespace RhinoInside.Revit.GH.Types
   [Kernel.Attributes.Name("Geometric Element")]
   public class GeometricElement : GraphicalElement, IGH_GeometricElement, IGH_PreviewMeshData, Bake.IGH_BakeAwareElement
   {
-    public override string DisplayName
-    {
-      get
-      {
-        if (Value is DB.Element element)
-        {
-          if (element.get_Parameter(DB.BuiltInParameter.ALL_MODEL_MARK) is DB.Parameter parameter && parameter.HasValue)
-          {
-            var mark = parameter.AsString();
-            if (!string.IsNullOrEmpty(mark))
-              return $"{base.DisplayName} [{mark}]";
-          }
-        }
-
-        return base.DisplayName;
-      }
-    }
-
     public GeometricElement() { }
     public GeometricElement(DB.Element element) : base(element) { }
 

--- a/src/RhinoInside.Revit.GH/Types/GeometryObject.cs
+++ b/src/RhinoInside.Revit.GH/Types/GeometryObject.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Linq;
-using System.Reflection;
-using GH_IO.Serialization;
 using Grasshopper;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Types;
@@ -9,7 +7,6 @@ using Rhino.Geometry;
 using RhinoInside.Revit.Convert.Display;
 using RhinoInside.Revit.Convert.Geometry;
 using RhinoInside.Revit.External.DB.Extensions;
-using RhinoInside.Revit.External.UI.Extensions;
 using RhinoInside.Revit.GH.Kernel.Attributes;
 using DB = Autodesk.Revit.DB;
 
@@ -29,7 +26,7 @@ namespace RhinoInside.Revit.GH.Types
     public override bool Equals(object obj) => (obj is GeometryObject<X> id) ? Equals(id) : base.Equals(obj);
     public override int GetHashCode() => DocumentGUID.GetHashCode() ^ UniqueID.GetHashCode();
 
-    public override sealed string ToString()
+    public sealed override string ToString()
     {
       string typeName = ((IGH_Goo) this).TypeName;
       if (!IsValid)
@@ -172,12 +169,19 @@ namespace RhinoInside.Revit.GH.Types
     #endregion
 
     protected GeometryObject() { }
-    protected GeometryObject(X data) : base(default, data) { }
     protected GeometryObject(DB.Document doc, DB.Reference reference)
     {
-      DocumentGUID = doc.GetFingerprintGUID();
-      UniqueID = reference.ConvertToStableRepresentation(doc);
+      try
+      {
+        Document = doc;
+        DocumentGUID = doc.GetFingerprintGUID();
+
+        this.reference = reference;
+        UniqueID = reference.ConvertToStableRepresentation(doc);
+      }
+      catch (Autodesk.Revit.Exceptions.InvalidObjectException) { }
     }
+
     public new X Value => base.Value as X;
 
     /// <summary>
@@ -213,7 +217,6 @@ namespace RhinoInside.Revit.GH.Types
     }
 
     public Vertex() { }
-    public Vertex(DB.Point data) : base(data) { }
     public Vertex(DB.Document doc, DB.Reference reference, int index) : base(doc, reference) { VertexIndex = index; }
 
     Point Point
@@ -293,7 +296,6 @@ namespace RhinoInside.Revit.GH.Types
   public class Edge : GeometryObject<DB.Edge>, IGH_PreviewData
   {
     public Edge() { }
-    public Edge(DB.Edge edge) : base(edge) { }
     public Edge(DB.Document doc, DB.Reference reference) : base(doc, reference) { }
 
     Curve Curve
@@ -374,7 +376,6 @@ namespace RhinoInside.Revit.GH.Types
   public class Face : GeometryObject<DB.Face>, IGH_PreviewData
   {
     public Face() { }
-    public Face(DB.Face face) : base(face) { }
     public Face(DB.Document doc, DB.Reference reference) : base(doc, reference) { }
 
     Curve[] Curves

--- a/src/RhinoInside.Revit.GH/Types/ProjectLocation.cs
+++ b/src/RhinoInside.Revit.GH/Types/ProjectLocation.cs
@@ -116,6 +116,8 @@ namespace RhinoInside.Revit.GH.Types
     public SiteLocation() { }
     public SiteLocation(DB.SiteLocation value) : base(value) { }
 
-    public override string DisplayName => Value?.PlaceName;
+    public override string DisplayName =>
+      Value?.PlaceName is string placeName && placeName.Length > 0?
+      placeName : base.DisplayName;
   }
 }

--- a/src/RhinoInside.Revit.GH/Types/View.cs
+++ b/src/RhinoInside.Revit.GH/Types/View.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Globalization;
+using Grasshopper.Kernel.Types;
 using DB = Autodesk.Revit.DB;
 
 namespace RhinoInside.Revit.GH.Types
@@ -13,6 +15,8 @@ namespace RhinoInside.Revit.GH.Types
     public static explicit operator DB.View(View value) => value?.Value;
     public new DB.View Value => base.Value as DB.View;
 
+    string IGH_Goo.TypeName => Value?.IsTemplate == true ? "Revit View Template" : "Revit View";
+
     public View() { }
     public View(DB.Document doc, DB.ElementId id) : base(doc, id) { }
     public View(DB.View view) : base(view) { }
@@ -21,11 +25,16 @@ namespace RhinoInside.Revit.GH.Types
     {
       get
       {
-        if(Value is DB.View view && !string.IsNullOrEmpty(view.Title))
-          return view.Title;
+        if (Value is DB.View view && !view.IsTemplate && ViewType is ViewType viewType)
+        {
+          FormattableString formatable = $"{viewType} : {view.Name}";
+          return formatable.ToString(CultureInfo.CurrentUICulture);
+        }
 
         return base.DisplayName;
       }
     }
+
+    public ViewType ViewType => Value is DB.View view ? new ViewType(view.ViewType) : default;
   }
 }

--- a/src/RhinoInside.Revit/External/DB/Extensions/BasePoint.cs
+++ b/src/RhinoInside.Revit/External/DB/Extensions/BasePoint.cs
@@ -34,21 +34,6 @@ namespace RhinoInside.Revit.External.DB.Extensions
     }
 
     /// <summary>
-    /// Gets the project internal origin base point for the document.
-    /// </summary>
-    /// <param name="doc">The document from which to get the internal origin base point.</param>
-    /// <returns>The project base point of the document.</returns>
-    public static BasePoint GetInternalOriginPoint(Document doc)
-    {
-      using (var collector = new FilteredElementCollector(doc))
-      {
-        var pointCollector = System.Linq.Enumerable.Cast<BasePoint>(collector.OfClass(typeof(BasePoint)));
-        pointCollector = System.Linq.Enumerable.Where(pointCollector, x => x.Category.Id.IntegerValue == (int) BuiltInCategory.OST_IOS_GeoSite);
-        return System.Linq.Enumerable.FirstOrDefault(pointCollector);
-      }
-    }
-
-    /// <summary>
     /// Gets the project base point for the document.
     /// </summary>
     /// <param name="doc">The document from which to get the project base point.</param>
@@ -80,6 +65,54 @@ namespace RhinoInside.Revit.External.DB.Extensions
       {
         var pointCollector = collector.OfCategory(BuiltInCategory.OST_SharedBasePoint);
         return pointCollector.FirstElement() as BasePoint;
+      }
+#endif
+    }
+  }
+}
+
+namespace RhinoInside.Revit.External.DB.Extensions
+{
+// TODO : Upgrade Revit 2021 nuget package to 2021.0.1 and change the if below to REVIT_2021
+#if !REVIT_2022
+  using InternalOrigin = Autodesk.Revit.DB.BasePoint;
+#endif
+
+  public static class InternalOriginExtension
+  {
+// TODO : Upgrade Revit 2021 nuget package to 2021.0.1 and change the if below to REVIT_2021
+#if REVIT_2022
+    /// <summary>
+    /// Gets the shared position of the InternalOrigin.
+    /// </summary>
+    /// <param name="basePoint"></param>
+    /// <returns></returns>
+    public static XYZ GetSharedPosition(this InternalOrigin basePoint) => basePoint.SharedPosition;
+
+    /// <summary>
+    /// Gets the position of the InternalOrigin.
+    /// </summary>
+    /// <param name="basePoint"></param>
+    /// <returns></returns>
+    public static XYZ GetPosition(this InternalOrigin basePoint) => basePoint.Position;
+#endif
+
+    /// <summary>
+    /// Gets the project internal origin base point for the document.
+    /// </summary>
+    /// <param name="doc">The document from which to get the internal origin base point.</param>
+    /// <returns>The project base point of the document.</returns>
+    public static InternalOrigin GetInternalOriginPoint(Document doc)
+    {
+// TODO : Upgrade Revit 2021 nuget package to 2021.0.1 and change the if below to REVIT_2021
+#if REVIT_2022
+      return InternalOrigin.Get(doc);
+#else
+      using (var collector = new FilteredElementCollector(doc))
+      {
+        var pointCollector = System.Linq.Enumerable.Cast<InternalOrigin>(collector.OfClass(typeof(InternalOrigin)));
+        pointCollector = System.Linq.Enumerable.Where(pointCollector, x => x.Category.Id.IntegerValue == (int) BuiltInCategory.OST_IOS_GeoSite);
+        return System.Linq.Enumerable.FirstOrDefault(pointCollector);
       }
 #endif
     }


### PR DESCRIPTION
* Removed unnamed built-in parameters from the picker.
* A `Exceptions.RuntimeArgumentException` should stop the component.
* Fixes #434
* Fixes #435 
* Fixes #436  
* Fixed 'Project Location' 'Internal Origin' output.
* Fixed 'Add Parameter' when input definition data-type is null.
* Fixed 'Element Parameter' when output 'Parameter' is added.
* Fixed 'View Identity' component when returning view templates.
* Unified `ToString` implementation across types.
* Fix for conversion Types.ViewType enum labels on Revit 2019.
