### PR TITLE
added option to element-geom component to exclude geom categories

### DIFF
--- a/src/RhinoInside.Revit/Convert/Geometry/GeometryDecoder.cs
+++ b/src/RhinoInside.Revit/Convert/Geometry/GeometryDecoder.cs
@@ -21,6 +21,7 @@ namespace RhinoInside.Revit.Convert.Geometry
       public DB.Element Element = default;
       public DB.Visibility Visibility = DB.Visibility.Invisible;
       public DB.ElementId GraphicsStyleId = DB.ElementId.InvalidElementId;
+      public DB.ElementId[] SkipGraphicsStyles = default;
       public DB.ElementId MaterialId = DB.ElementId.InvalidElementId;
       public DB.ElementId[] FaceMaterialId;
     }
@@ -254,6 +255,19 @@ namespace RhinoInside.Revit.Convert.Geometry
 
     public static IEnumerable<GeometryBase> ToGeometryBaseMany(this DB.GeometryObject geometry)
     {
+      // if context contains geometry styles to be skipped, then skip
+      var context = Context.Peek;
+      if (context.Element is object && context.SkipGraphicsStyles is DB.ElementId[])
+      {
+        var doc = context.Element.Document;
+        if (doc.GetElement(geometry.GraphicsStyleId) is DB.GraphicsStyle style
+              && context.SkipGraphicsStyles.Contains(style.GraphicsStyleCategory.Id))
+        {
+          yield return null;
+          yield break;
+        }
+      }
+
       UpdateGraphicAttributes(geometry);
 
       switch (geometry)


### PR DESCRIPTION
Adds a new optional input to the Element Geometry component to exclude given geometry category types.

Closes #150

![Screen Shot 2021-08-09 at 1 56 48 PM](https://user-images.githubusercontent.com/8197916/128773781-473e1439-32c5-43d6-8833-4a26cc1348fd.png)

Test Files:
[LightFGeom.zip](https://github.com/mcneel/rhino.inside-revit/files/6957387/LightFGeom.zip)
