### PR TITLE
Update Element.cs

### DIFF
--- a/src/RhinoInside.Revit.GH/Parameters/Element.cs
+++ b/src/RhinoInside.Revit.GH/Parameters/Element.cs
@@ -11,7 +11,7 @@ using DB = Autodesk.Revit.DB;
 
 namespace RhinoInside.Revit.GH.ElementTracking
 {
-  internal static class TrackingParamElementExtensions
+  public static class TrackingParamElementExtensions
   {
     /// <summary>
     /// Reads an element from <paramref name="name"/> parameter.


### PR DESCRIPTION
@kike-garbo as discussed we make TrackingParamElementExtensions public to allow us access class ElementTracking for external tools like SAM.