### PR TITLE
Use vs2019 for github actions build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
   test:
     name: test
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
       - uses: microsoft/setup-msbuild@v1


### PR DESCRIPTION
windows-latest now points to 2022

Pinning to windows-2019 should fix [this problem](https://github.com/mcneel/rhino.inside-revit/runs/5319161525?check_suite_focus=true), for now