### PR TITLE
Fix for `DirectContext3DServer.Primitive.Regen` for curves with more …

### DIFF
--- a/src/RhinoInside.Revit/DirectContext3DServer.cs
+++ b/src/RhinoInside.Revit/DirectContext3DServer.cs
@@ -799,15 +799,13 @@ namespace RhinoInside.Revit
               {
                 if (polyline?.ToPolyline() is Polyline pline)
                 {
-
                   // Reduce too complex polylines.
                   {
                     var ctol = tol.VertexTolerance;
                     while (pline.Count > 0x4000)
                     {
                       ctol *= 2.0;
-                      if (pline.ReduceSegments(ctol) == 0)
-                        break;
+                      pline.ReduceSegments(ctol);
                     }
                   }
 


### PR DESCRIPTION
…that 16K vertices.