### PR TITLE
Solves an issue with invalid outlines

### DIFF
--- a/src/RhinoInside.Revit.GH/Components/Element/Floor/ByOutline.cs
+++ b/src/RhinoInside.Revit.GH/Components/Element/Floor/ByOutline.cs
@@ -98,6 +98,7 @@ namespace RhinoInside.Revit.GH.Components.Families
 
         using (var properties = AreaMassProperties.Compute(loop))
         {
+          if (properties is null) return;
           if (properties.Area > maxArea)
           {
             normal = plane.Normal;


### PR DESCRIPTION
I hope this helpful to open a pull request, if not, I can create an issue or something but I couldn't find much in the way of guidelines for this. So I've done my best.

---

We have a project we're pushing from Rhino into Revit through RiR. Some of the curves in this particular file seem to cause the AreaMassProperties to fail which wasn't getting caught and threw an error preventing the import. 
![image](https://user-images.githubusercontent.com/28632338/221921161-3f7ca685-3d45-4bd8-859d-293a67c9e9c8.png)


Adding a null check seems to allow the import to continue even on failure. Maybe it shouldn't, but it seems to work fine.
![image](https://user-images.githubusercontent.com/28632338/221921247-6c35ecb4-d096-4f43-8b83-219d08cebc24.png)

I have isolated the curves that create the issue inside of a GH script which I hope you can use to replicate.

(I had to rename this ghx as .txt so Github would be happy)
[error-script-example.txt](https://github.com/mcneel/rhino.inside-revit/files/10853046/error-script-example.txt)