### PR TITLE
Now the Grasshopper Editor window stays at same position…

### DIFF
--- a/docs/pages/_en/1.0/reference/release-notes.md
+++ b/docs/pages/_en/1.0/reference/release-notes.md
@@ -12,6 +12,7 @@ group: Deployment & Configs
 
 ### RC
 
+- Now the Grasshopper Editor window stays at same position after picking from Revit.
 
 {% endcapture %}
 {% include ltr/release_header_next.html title="Upcoming Changes" note=rc_release_notes %}

--- a/src/RhinoInside.Revit.GH/Parameters/Reference.cs
+++ b/src/RhinoInside.Revit.GH/Parameters/Reference.cs
@@ -138,8 +138,37 @@ namespace RhinoInside.Revit.GH.Parameters
       }
     }
 
-    protected override void PrepareForPrompt() { }
-    protected override void RecoverFromPrompt() { }
+    static System.Drawing.Rectangle? _EditorBounds;
+    protected override void PrepareForPrompt()
+    {
+      if (Grasshopper.Instances.DocumentEditor is Form editor)
+      {
+        if (editor.Visible)
+        {
+          _EditorBounds = editor.Bounds;
+          editor.Hide();
+        }
+      }
+    }
+
+    protected override void RecoverFromPrompt()
+    {
+      if (Grasshopper.Instances.DocumentEditor is Form editor)
+      {
+        if (_EditorBounds.HasValue)
+        {
+          editor.Bounds = _EditorBounds.Value;
+
+          if (!editor.Visible)
+          {
+            editor.Show();
+            editor.Select();
+          }
+        }
+      }
+
+      _EditorBounds = default;
+    }
     #endregion
 
     #region IGH_ReferenceParam


### PR DESCRIPTION
after picking from Revit.