### PR TITLE
Added `ARUI.UIApplication.LookupPostableCommandId` extension method.

### DIFF
--- a/src/RhinoInside.Revit.AddIn/Commands/AddIn/CommandStart.cs
+++ b/src/RhinoInside.Revit.AddIn/Commands/AddIn/CommandStart.cs
@@ -297,7 +297,7 @@ namespace RhinoInside.Revit.AddIn.Commands
           }
         )
         {
-          if (RevitCommandId.LookupPostableCommandId(PostableCommand.KeyboardShortcuts) is RevitCommandId commandId)
+          if (Revit.ActiveUIApplication.LookupPostableCommandId(PostableCommand.KeyboardShortcuts) is RevitCommandId commandId)
           {
             taskDialog.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Customize keyboard shortcuts…");
 

--- a/src/RhinoInside.Revit.AddIn/Loader.cs
+++ b/src/RhinoInside.Revit.AddIn/Loader.cs
@@ -1,11 +1,11 @@
 using System;
 using Autodesk.Revit.UI;
 using static RhinoInside.Revit.Diagnostics;
-using UIX = RhinoInside.Revit.External.UI;
+using ERUI = RhinoInside.Revit.External.UI;
 
 namespace RhinoInside.Revit.AddIn
 {
-  public class Loader : UIX.ExternalApplication, UIX.IHostedApplication
+  public class Loader : ERUI.ExternalApplication, ERUI.IHostedApplication
   {
     public Loader() : base(new Guid("02EFF7F0-4921-4FD3-91F6-A87B6BA9BF74")) => Instance = this;
 
@@ -30,9 +30,9 @@ namespace RhinoInside.Revit.AddIn
 
       // Initialize UI
       {
-        Commands.CommandStart.CreateUI(app);
-
         StartupOnApplicationInitialized();
+
+        Commands.CommandStart.CreateUI(app);
       }
 
       // Check For Updates
@@ -82,13 +82,14 @@ namespace RhinoInside.Revit.AddIn
       Core.Host.Services.ApplicationInitialized += applicationInitialized = (sender, args) =>
       {
         Core.Host.Services.ApplicationInitialized -= applicationInitialized;
+
         if (Core.CurrentStatus < Core.Status.Available) return;
         if (Commands.CommandStart.Start() == Result.Succeeded)
         {
           if (Core.StartupMode == CoreStartupMode.Scripting)
           {
-            if (RevitCommandId.LookupPostableCommandId(PostableCommand.ExitRevit) is RevitCommandId commandId)
-              Core.Host.PostCommand(commandId);
+            if (ERUI.Extensions.UIApplicationExtension.LookupPostableCommandId(null, PostableCommand.ExitRevit) is RevitCommandId cmdExitRevit)
+              Core.Host.PostCommand(cmdExitRevit);
             else
               Revit.MainWindow.TryClose();
           }
@@ -120,11 +121,11 @@ namespace RhinoInside.Revit.AddIn
     #endregion
 
     #region IHostedApplication
-    void UIX.IHostedApplication.InvokeInHostContext(Action action) => Rhinoceros.InvokeInHostContext(action);
-    T UIX.IHostedApplication.InvokeInHostContext<T>(Func<T> func) => Rhinoceros.InvokeInHostContext(func);
+    void ERUI.IHostedApplication.InvokeInHostContext(Action action) => Rhinoceros.InvokeInHostContext(action);
+    T ERUI.IHostedApplication.InvokeInHostContext<T>(Func<T> func) => Rhinoceros.InvokeInHostContext(func);
 
-    bool UIX.IHostedApplication.DoEvents() => Rhinoceros.Run();
-    Microsoft.Win32.SafeHandles.WindowHandle UIX.IHostedApplication.MainWindow => Rhinoceros.MainWindow;
+    bool ERUI.IHostedApplication.DoEvents() => Rhinoceros.Run();
+    Microsoft.Win32.SafeHandles.WindowHandle ERUI.IHostedApplication.MainWindow => Rhinoceros.MainWindow;
     #endregion
   }
 }

--- a/src/RhinoInside.Revit.External/UI/Extensions/UIApplication.cs
+++ b/src/RhinoInside.Revit.External/UI/Extensions/UIApplication.cs
@@ -9,18 +9,37 @@ namespace RhinoInside.Revit.External.UI.Extensions
 {
   public static class UIApplicationExtension
   {
-    internal static IList<UIDocument> GetOpenUIDocuments(this UIApplication app)
-    {
-      return HostedApplication.Active.InvokeInHostContext
-      (
-        () =>
-        app.Application.Documents.Cast<Document>().
-        Where(x => !x.IsLinked).
-        Select(x => new UIDocument(x)).
-        Where(x => x.GetOpenUIViews().Count > 0).
-        ToArray()
-      );
-    }
+    /// <summary>
+    ///  Looks up and retrieves the Revit command id with the given id string.
+    /// </summary>
+    /// <remarks>Looks like there is a bug on `RevitCommandId.LookupPostableCommandId` when resulting `RevitCommandId.Name` is an integer.</remarks>
+    /// <param name="app"></param>
+    /// <param name="postableCommand"></param>
+    /// <returns>The Revit command id. Returns null if the command is not found.</returns>
+    internal static RevitCommandId LookupPostableCommandId(this UIApplication app, PostableCommand postableCommand) => HostedApplication.Active.InvokeInHostContext
+    (
+      () =>
+      {
+        var commandId = default (RevitCommandId);
+        try { commandId = RevitCommandId.LookupPostableCommandId(postableCommand); }
+        catch { }
+
+        if (commandId is null)
+          app?.Application.WriteJournalComment($"{nameof(PostableCommand)} = {postableCommand} is not available.", timeStamp: true);
+
+        return commandId;
+      }
+    );
+
+    internal static IList<UIDocument> GetOpenUIDocuments(this UIApplication app) => HostedApplication.Active.InvokeInHostContext
+    (
+      () =>
+      app.Application.Documents.Cast<Document>().
+      Where(x => !x.IsLinked).
+      Select(x => new UIDocument(x)).
+      Where(x => x.GetOpenUIViews().Count > 0).
+      ToArray()
+    );
 
     public static bool TryGetDocument(this UIApplication app, Guid guid, out Document document) =>
       app.Application.Documents.Cast<Document>().TryGetDocument(guid, out document, app.ActiveUIDocument?.Document);

--- a/src/RhinoInside.Revit.External/UI/Extensions/UIDocument.cs
+++ b/src/RhinoInside.Revit.External/UI/Extensions/UIDocument.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
@@ -77,17 +76,9 @@ namespace RhinoInside.Revit.External.UI.Extensions
     {
       commandId = default;
       if (uiDocument is null) return false;
-      if (!System.Enum.IsDefined(typeof(PostableCommand), postableCommand)) return false;
 
-      commandId = HostedApplication.Active?.InvokeInHostContext
-      (
-        () =>
-        {
-          var id = RevitCommandId.LookupPostableCommandId(postableCommand);
-          if (id is object && id.IsValidObject && uiDocument.Application.CanPostCommand(id)) return id;
-          return default;
-        }
-      );
+      commandId = uiDocument.Application.LookupPostableCommandId(postableCommand);
+      if (commandId is null) return false;
 
       if (uiDocument.Document.IsFamilyDocument)
       {


### PR DESCRIPTION
Looks like there is a bug on `RevitCommandId.LookupPostableCommandId` when resulting `RevitCommandId.Name` is an integer.