### PR TITLE
Renamed 'Document Warnings' -> 'Query Warnings'.

### DIFF
--- a/docs/pages/_en/1.0/reference/release-notes.md
+++ b/docs/pages/_en/1.0/reference/release-notes.md
@@ -16,6 +16,8 @@ group: Deployment & Configs
 
 - Added 'Pick Elements' component.
 - Added 'Pick Points' component.
+- Renamed 'Document Warnings' -> 'Query Warnings'.
+- Added context menu to 'Built-In Failure Definitions' to filter by severity.
 
 {% endcapture %}
 {% include ltr/release_header_next.html title="Upcoming Changes" note=rc_release_notes %}

--- a/src/RhinoInside.Revit.External/DB/Extensions/FilteredElementCollector.cs
+++ b/src/RhinoInside.Revit.External/DB/Extensions/FilteredElementCollector.cs
@@ -52,6 +52,11 @@ namespace RhinoInside.Revit.External.DB.Extensions
 
   public static class FilteredElementCollectorExtension
   {
+    internal static ICollection<ElementId> ToReadOnlyElementIdCollection(this ICollection<ElementId> collection)
+    {
+      return new ReadOnlySortedElementIdCollection(collection);
+    }
+
     public static ICollection<ElementId> ToReadOnlyElementIdCollection(this FilteredElementCollector collector)
     {
       return new ReadOnlySortedElementIdCollection(collector.ToElementIds());

--- a/src/RhinoInside.Revit.GH/Components/Documents/DocumentWarnings.cs
+++ b/src/RhinoInside.Revit.GH/Components/Documents/DocumentWarnings.cs
@@ -55,7 +55,7 @@ namespace RhinoInside.Revit.GH.Components.Documents
         }, ParamRelevance.Primary
       ),
       ParamDefinition.Create<Parameters.Element>("Failing Element", "FE", "Element that caused the failure.", optional: true, relevance: ParamRelevance.Primary),
-      ParamDefinition.Create<Parameters.Element>("Additional Elements", "AE", "List of additional reference elements for the failure.", access: GH_ParamAccess.list, relevance: ParamRelevance.Secondary),
+      ParamDefinition.Create<Parameters.Element>("Additional Elements", "AE", "List of additional reference elements for the failure.", optional: true, access: GH_ParamAccess.list, relevance: ParamRelevance.Secondary),
     };
 
     protected override ParamDefinition[] Outputs => outputs;

--- a/src/RhinoInside.Revit.GH/Components/Documents/DocumentWarnings.cs
+++ b/src/RhinoInside.Revit.GH/Components/Documents/DocumentWarnings.cs
@@ -1,13 +1,18 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Parameters;
+using ARDB = Autodesk.Revit.DB;
+using OS = System.Environment;
 
 namespace RhinoInside.Revit.GH.Components.Documents
 {
-  [ComponentVersion(introduced: "1.10"), ComponentRevitAPIVersion(min: "2018.0")]
+  using External.DB.Extensions;
+
+  [ComponentVersion(introduced: "1.10", updated: "1.17"), ComponentRevitAPIVersion(min: "2018.0")]
   public class DocumentWarnings : ZuiComponent
   {
     public override Guid ComponentGuid => new Guid("3917ADB2-706E-49A2-A3AF-6B5F610C4B78");
@@ -25,7 +30,7 @@ namespace RhinoInside.Revit.GH.Components.Documents
 
     public DocumentWarnings() : base
     (
-      name: "Document Warnings",
+      name: "Query Warnings",
       nickname: "Warnings",
       description: "Gets a list of failure messages generated from persistent (reviewable) warnings accumulated in the document.",
       category: "Revit",
@@ -37,6 +42,20 @@ namespace RhinoInside.Revit.GH.Components.Documents
     static readonly ParamDefinition[] inputs =
     {
       new ParamDefinition(new Parameters.Document(), ParamRelevance.Occasional),
+      new ParamDefinition
+      (
+        new Param_GenericObject()
+        {
+          Name = "Failure Definitions",
+          NickName = "FD",
+          Description = "Set of failure definitions to query.",
+          Access = GH_ParamAccess.list,
+          Hidden = true,
+          Optional = true,
+        }, ParamRelevance.Primary
+      ),
+      ParamDefinition.Create<Parameters.Element>("Failing Element", "FE", "Element that caused the failure.", optional: true, relevance: ParamRelevance.Primary),
+      ParamDefinition.Create<Parameters.Element>("Additional Elements", "AE", "List of additional reference elements for the failure.", access: GH_ParamAccess.list, relevance: ParamRelevance.Secondary),
     };
 
     protected override ParamDefinition[] Outputs => outputs;
@@ -47,7 +66,7 @@ namespace RhinoInside.Revit.GH.Components.Documents
       (
         new Param_GenericObject()
         {
-          Name = "Failure Definition",
+          Name = "Failure Definitions",
           NickName = "FD",
           Description = "Failure definition.",
           Access = GH_ParamAccess.list,
@@ -59,27 +78,92 @@ namespace RhinoInside.Revit.GH.Components.Documents
       (
         new Param_String()
         {
-          Name = "Description",
+          Name = "Descriptions",
           NickName = "D",
           Description = "Failure definition description.",
           Access = GH_ParamAccess.list,
           DataMapping = GH_DataMapping.Graft
-        }, ParamRelevance.Primary
+        }, ParamRelevance.Occasional
       ),
       ParamDefinition.Create<Parameters.Element>("Failing Elements", "FE", "List of elements that caused the failure.", access: GH_ParamAccess.tree, relevance: ParamRelevance.Primary),
       ParamDefinition.Create<Parameters.Element>("Additional Elements", "AE", "List of additional reference elements for the failure.", access: GH_ParamAccess.tree, relevance: ParamRelevance.Primary),
     };
+
+    public override void AddedToDocument(GH_Document document)
+    {
+      if (Params.Output<IGH_Param>("Failure Definition") is IGH_Param failureDefinition)
+        failureDefinition.Name = "Failure Definitions";
+
+      if (Params.Output<IGH_Param>("Description") is IGH_Param description)
+        description.Name = "Descriptions";
+
+      base.AddedToDocument(document);
+    }
+
+    static string GetDescriptionText(ARDB.FailureMessage message)
+    {
+      if (message?.GetDescriptionText() is string description)
+      {
+        if (description != string.Empty)
+        {
+          description = description.Trim();
+          description = description.Replace("...", "…");
+          var lines = description.Split(new string[] { ". ", "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+          description = string.Join
+          (
+            OS.NewLine,
+            lines.Select
+            (
+              x =>
+              {
+                var line = x.Trim();
+                if (line != string.Empty && !char.IsPunctuation(line[line.Length - 1]))
+                  line += '.';
+
+                return line;
+              }
+            )
+          );
+        }
+
+        return description;
+      }
+
+      return null;
+    }
 
     protected override void TrySolveInstance(IGH_DataAccess DA)
     {
       if (!Parameters.Document.TryGetDocumentOrCurrent(this, DA, "Document", out var doc)) return;
       else Params.TrySetData(DA, "Document", () => doc);
 
+      if (!Params.TryGetDataList(DA, "Failure Definitions", out IList<Types.FailureDefinition> failureDefinitions)) return;
+      if (!Params.TryGetData(DA, "Failing Element", out Types.Element element)) return;
+      if (!Params.TryGetData(DA, "Additional Elements", out IList<Types.Element> additionals)) return;
+
 #if REVIT_2018
       var warnings = doc.Value.GetWarnings();
 
-      Params.TrySetDataList(DA, "Failure Definition", () => warnings.Select(x => new Types.FailureDefinition(x.GetFailureDefinitionId().Guid)));
-      Params.TrySetDataList(DA, "Description", () => warnings.Select(x => x.GetDescriptionText()));
+      if (failureDefinitions is object)
+      {
+        var definitions = new HashSet<Guid>(failureDefinitions.Select(x => x.Value));
+        warnings = warnings.Where(x => definitions.Contains(x.GetFailureDefinitionId().Guid)).ToArray();
+      }
+
+      if (element is object)
+      {
+        var elementId = element.Id;
+        warnings = warnings.Where(x => x.GetFailingElements().ToReadOnlyElementIdCollection().Contains(elementId)).ToArray();
+      }
+
+      if (additionals is object && additionals.Count > 0)
+      {
+        var additional = new HashSet<ARDB.ElementId>(additionals.Where(x => doc.Value.IsEquivalent(x?.Document)).Select(x => x.Id));
+        warnings = warnings.Where(x => additional.Overlaps(x.GetAdditionalElements())).ToArray();
+      }
+
+      Params.TrySetDataList(DA, "Failure Definitions", () => warnings.Select(x => new Types.FailureDefinition(x.GetFailureDefinitionId().Guid)));
+      Params.TrySetDataList(DA, "Descriptions", () => warnings.Select(GetDescriptionText));
 
       var _FailingElements_ = Params.IndexOfOutputParam("Failing Elements");
       if (_FailingElements_ != -1)

--- a/src/RhinoInside.Revit.GH/Parameters/Input/BuiltInFailureDefinitions.cs
+++ b/src/RhinoInside.Revit.GH/Parameters/Input/BuiltInFailureDefinitions.cs
@@ -1,10 +1,14 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Windows.Forms;
+using GH_IO.Serialization;
 using Grasshopper.Kernel;
+using ARDB = Autodesk.Revit.DB;
 
 namespace RhinoInside.Revit.GH.Parameters.Input
 {
-  [ComponentVersion(introduced: "1.10")]
+  [ComponentVersion(introduced: "1.10", updated: "1.17")]
   public class BuiltInFailureDefinitions : Grasshopper.Special.ValueSet<Types.FailureDefinition>
   {
     public override Guid ComponentGuid => new Guid("73E14FBB-24EA-44FE-85ED-5D028154029B");
@@ -13,6 +17,8 @@ namespace RhinoInside.Revit.GH.Parameters.Input
     protected override System.Drawing.Bitmap Icon =>
       ((System.Drawing.Bitmap) Properties.Resources.ResourceManager.GetObject(GetType().Name)) ??
       base.Icon;
+
+    public ARDB.FailureSeverity FailureSeverity = ARDB.FailureSeverity.Warning;
 
     public BuiltInFailureDefinitions() : base
     (
@@ -30,12 +36,92 @@ namespace RhinoInside.Revit.GH.Parameters.Input
     {
       if (SourceCount == 0)
       {
+        MutableNickName = false;
+        if (FailureSeverity == ARDB.FailureSeverity.None)
+        {
+          NickName = Name;
+        }
+        else
+        {
+          NickName = $"{Name} ({Types.FailureSeverity.NamedValues[(int) FailureSeverity]})";
+        }
+
         m_data.Clear();
         using (var registry = Autodesk.Revit.ApplicationServices.Application.GetFailureDefinitionRegistry())
-          m_data.AppendRange(registry.ListAllFailureDefinitions().Select(x => new Types.FailureDefinition(x.GetId().Guid)));
+        {
+          var definitions = registry.ListAllFailureDefinitions() as IEnumerable<ARDB.FailureDefinitionAccessor>;
+          if (FailureSeverity != ARDB.FailureSeverity.None)
+            definitions = definitions.Where(x => x.GetSeverity() == FailureSeverity);
+
+          m_data.AppendRange(definitions.Select(x => new Types.FailureDefinition(x.GetId().Guid)));
+        }
+      }
+      else
+      {
+        MutableNickName = true;
       }
 
       base.LoadVolatileData();
+    }
+
+    protected override void Menu_AppendPromptOne(ToolStripDropDown menu)
+    {
+      base.Menu_AppendPromptOne(menu);
+
+      if (SourceCount == 0 && Kind == GH_ParamKind.floating)
+      {
+        var severities = new ARDB.FailureSeverity[]
+        {
+          ARDB.FailureSeverity.Warning,
+          ARDB.FailureSeverity.Error,
+          ARDB.FailureSeverity.DocumentCorruption
+        };
+
+        foreach (var severity in severities)
+        {
+          var text = severity == ARDB.FailureSeverity.None ? "All" : Types.FailureSeverity.NamedValues[(int) severity];
+          var item = Menu_AppendItem(menu, text, Menu_SeverityClicked, true, severity.Equals(FailureSeverity));
+          item.Tag = severity;
+        }
+      }
+    }
+
+    private void Menu_SeverityClicked(object sender, EventArgs e)
+    {
+      if (sender is ToolStripMenuItem item)
+      {
+        if (item.Tag is ARDB.FailureSeverity value)
+        {
+          RecordUndoEvent("Set Failure Severity");
+          FailureSeverity = value;
+          OnObjectChanged(GH_ObjectEventType.Custom);
+
+          ExpireSolution(true);
+        }
+      }
+    }
+
+    public override bool Read(GH_IReader reader)
+    {
+      if (!base.Read(reader))
+        return false;
+
+      int failureSeverity = (int) ARDB.FailureSeverity.None;
+      reader.TryGetInt32(nameof(FailureSeverity), ref failureSeverity);
+      FailureSeverity = (ARDB.FailureSeverity) failureSeverity;
+
+      return true;
+    }
+
+    public override bool Write(GH_IWriter writer)
+    {
+      if (!base.Write(writer))
+        return false;
+
+      if (FailureSeverity != ARDB.FailureSeverity.None)
+        writer.SetInt32(nameof(FailureSeverity), (int) FailureSeverity);
+
+      return true;
     }
   }
 }

--- a/src/RhinoInside.Revit.GH/Types/Enums.cs
+++ b/src/RhinoInside.Revit.GH/Types/Enums.cs
@@ -7,6 +7,26 @@ namespace RhinoInside.Revit.GH.Types
   using Kernel.Attributes;
 
   [
+    ComponentVersion(introduced: "1.17"),
+    ComponentGuid("128BC177-9A7F-43D5-8BF9-5432F357270A"),
+    Name("Failure Severity"),
+    Description("Contains a collection of Revit failure severity values"),
+  ]
+  public class FailureSeverity : GH_Flags<ARDB.FailureSeverity>
+  {
+    public override bool IsEmpty => Value == ARDB.FailureSeverity.None;
+    public static new ReadOnlyDictionary<int, string> NamedValues { get; } = new ReadOnlyDictionary<int, string>
+    (
+      new Dictionary<int, string>
+      {
+        { (int) ARDB.FailureSeverity.Warning,             "Warning"    },
+        { (int) ARDB.FailureSeverity.Error,               "Error"      },
+        { (int) ARDB.FailureSeverity.DocumentCorruption,  "Corruption" },
+      }
+    );
+  }
+
+  [
     ComponentGuid("4615F47E-A20E-448A-A5DB-AF3473867E3D"),
     Name("Element Kind"),
     Description("Contains a collection of Revit element kind values"),


### PR DESCRIPTION
Added context menu to 'Built-In Failure Definitions' to filter by severity.