### PR TITLE
SDK style conflict with AssemblyInfo generation

### DIFF
--- a/src/RhinoInside.Revit.AddIn/RhinoInside.Revit.AddIn.csproj
+++ b/src/RhinoInside.Revit.AddIn/RhinoInside.Revit.AddIn.csproj
@@ -6,6 +6,7 @@
   <PropertyGroup>
     <AssemblyName>RhinoInside.Revit.AddIn</AssemblyName>
     <RootNamespace>RhinoInside.Revit.AddIn</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RhinoInside.Revit.External/RhinoInside.Revit.External.csproj
+++ b/src/RhinoInside.Revit.External/RhinoInside.Revit.External.csproj
@@ -6,6 +6,7 @@
   <PropertyGroup>
     <AssemblyName>RhinoInside.Revit.External</AssemblyName>
     <RootNamespace>RhinoInside.Revit.External</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RhinoInside.Revit.GH/RhinoInside.Revit.GH.csproj
+++ b/src/RhinoInside.Revit.GH/RhinoInside.Revit.GH.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>RhinoInside.Revit.GH</AssemblyName>
     <RootNamespace>RhinoInside.Revit.GH</RootNamespace>
     <Title>Rhino.Inside for Autodesk Revit</Title>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RhinoInside.Revit.Loader/RhinoInside.Revit.Loader.csproj
+++ b/src/RhinoInside.Revit.Loader/RhinoInside.Revit.Loader.csproj
@@ -6,6 +6,7 @@
     <Configurations>Debug-2017;Release-2017;Debug-2018;Release-2018;Debug-2019;Release-2019;Debug-2020;Release-2020;Debug-2021;Release-2021;Debug-2022;Release-2022;Debug-2023;Release-2023;Debug-2024;Release-2024;Debug-2025;Release-2025;</Configurations>
     <AssemblyName>RhinoInside.Revit.Loader</AssemblyName>
     <RootNamespace>RhinoInside.Revit.Loader</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RhinoInside.Revit/RhinoInside.Revit.csproj
+++ b/src/RhinoInside.Revit/RhinoInside.Revit.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>RhinoInside.Revit</AssemblyName>
     <RootNamespace>RhinoInside.Revit</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bug fix when building RiR from source. This error happens to all System.Reflection assembly attributes auto-generated across multiple RiR projects. This is a known conflict between SDK style csproj file and MSBuild csproj file.

- Error (active) CS0579 Duplicate 'System.Reflection.AssemblyCompanyAttribute' attribute RhinoInside.Revit.External D:\Github\rhino.inside-revit\src\RhinoInside.Revit.External\obj\Debug-2024-R7\net481\RhinoInside.Revit.External.AssemblyInfo.cs 14

- The error CS0579 indicates that the AssemblyCompanyAttribute has been defined more than once for the project RhinoInside.Revit.External. This can happen if the attribute is explicitly defined in your code (e.g., within AssemblyInfo.cs or another file) and also generated automatically during the build process based on project properties.

- Prefer to keep the attribute definitions in the code, we can disable the automatic generation of the AssemblyInfo.cs file by the build system.