### PR TITLE
Add IFC, Revit, CAD, 3DM, and OBJ Link Components with Level-based Placement

### DIFF
--- a/src/RhinoInside.Revit.GH/Components/Import/IFCImportOptions.cs
+++ b/src/RhinoInside.Revit.GH/Components/Import/IFCImportOptions.cs
@@ -1,0 +1,172 @@
+using System;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+using ARDB = Autodesk.Revit.DB;
+
+namespace RhinoInside.Revit.GH.Components.Import
+{
+  [ComponentVersion(introduced: "1.34")]
+  public class IFCImportOptions : ZuiComponent
+  {
+    public override Guid ComponentGuid => new Guid("A8F3E5C1-9D4B-4E2A-B8F1-3C5D6E7F8A9B");
+    public override GH_Exposure Exposure => GH_Exposure.tertiary;
+    protected override string IconTag => string.Empty;
+
+    public IFCImportOptions() : base
+    (
+      name: "IFC Import Options",
+      nickname: "IFCOpt",
+      description: "Configure options for IFC file import or link operations",
+      category: "Revit",
+      subCategory: "Insert"
+    )
+    { }
+
+    protected override ParamDefinition[] Inputs => inputs;
+    static readonly ParamDefinition[] inputs =
+    {
+      new ParamDefinition
+      (
+        new Param_GenericObject
+        {
+          Name = "IFC Import Options",
+          NickName = "O",
+          Description = "IFC import options object (optional, will create new if not provided)",
+          Optional = true
+        }, ParamRelevance.Primary
+      ),
+      new ParamDefinition
+      (
+        new Param_Integer
+        {
+          Name = "Intent",
+          NickName = "I",
+          Description = "Import intent:\n  0 = Parametric (standard Revit elements for editing)\n  1 = Reference (lightweight accurate representations, not editable)",
+          Optional = true
+        }, ParamRelevance.Primary
+      ),
+      new ParamDefinition
+      (
+        new Param_Integer
+        {
+          Name = "Action",
+          NickName = "A",
+          Description = "Import action:\n  0 = Open (open IFC as new document)\n  1 = Link (link IFC to current document)",
+          Optional = true
+        }, ParamRelevance.Primary
+      ),
+      new ParamDefinition
+      (
+        new Param_Boolean
+        {
+          Name = "Auto Join",
+          NickName = "AJ",
+          Description = "Enable or disable auto-join at the end of import",
+          Optional = true
+        }, ParamRelevance.Secondary
+      ),
+      new ParamDefinition
+      (
+        new Param_Boolean
+        {
+          Name = "Autocorrect Off Axis Lines",
+          NickName = "AC",
+          Description = "Enable or disable correcting lines that are slightly off-axis",
+          Optional = true
+        }, ParamRelevance.Secondary
+      )
+    };
+
+    protected override ParamDefinition[] Outputs => outputs;
+    static readonly ParamDefinition[] outputs =
+    {
+      new ParamDefinition
+      (
+        new Param_GenericObject
+        {
+          Name = "IFC Import Options",
+          NickName = "O",
+          Description = "IFC import options object",
+          Access = GH_ParamAccess.item
+        }
+      ),
+      new ParamDefinition
+      (
+        new Param_Integer
+        {
+          Name = "Intent",
+          NickName = "I",
+          Description = "Import intent value",
+          Access = GH_ParamAccess.item
+        }
+      ),
+      new ParamDefinition
+      (
+        new Param_Integer
+        {
+          Name = "Action",
+          NickName = "A",
+          Description = "Import action value",
+          Access = GH_ParamAccess.item
+        }
+      ),
+      new ParamDefinition
+      (
+        new Param_Boolean
+        {
+          Name = "Auto Join",
+          NickName = "AJ",
+          Description = "Auto-join enabled",
+          Access = GH_ParamAccess.item
+        }
+      ),
+      new ParamDefinition
+      (
+        new Param_Boolean
+        {
+          Name = "Autocorrect Off Axis Lines",
+          NickName = "AC",
+          Description = "Autocorrect off-axis lines enabled",
+          Access = GH_ParamAccess.item
+        }
+      )
+    };
+
+    protected override void TrySolveInstance(IGH_DataAccess DA)
+    {
+      ARDB.IFC.IFCImportOptions options = null;
+      if (Params.TryGetData(DA, "IFC Import Options", out ARDB.IFC.IFCImportOptions inputOptions) && inputOptions != null)
+        options = inputOptions;
+      else
+        options = new ARDB.IFC.IFCImportOptions();
+
+      if (Params.TryGetData(DA, "Intent", out int? intent) && intent.HasValue)
+      {
+        if (Enum.IsDefined(typeof(ARDB.IFC.IFCImportIntent), intent.Value))
+          options.Intent = (ARDB.IFC.IFCImportIntent)intent.Value;
+      }
+
+      if (Params.TryGetData(DA, "Action", out int? action) && action.HasValue)
+      {
+        if (Enum.IsDefined(typeof(ARDB.IFC.IFCImportAction), action.Value))
+          options.Action = (ARDB.IFC.IFCImportAction)action.Value;
+      }
+
+      if (Params.TryGetData(DA, "Auto Join", out bool? autoJoin) && autoJoin.HasValue)
+        options.AutoJoin = autoJoin.Value;
+
+      if (Params.TryGetData(DA, "Autocorrect Off Axis Lines", out bool? autocorrect) && autocorrect.HasValue)
+        options.AutocorrectOffAxisLines = autocorrect.Value;
+
+      DA.SetData("IFC Import Options", options);
+
+      if (options != null)
+      {
+        DA.SetData("Intent", (int)options.Intent);
+        DA.SetData("Action", (int)options.Action);
+        DA.SetData("Auto Join", options.AutoJoin);
+        DA.SetData("Autocorrect Off Axis Lines", options.AutocorrectOffAxisLines);
+      }
+    }
+  }
+}

--- a/src/RhinoInside.Revit.GH/Components/Import/Link3DM.cs
+++ b/src/RhinoInside.Revit.GH/Components/Import/Link3DM.cs
@@ -1,0 +1,130 @@
+using System;
+using Autodesk.Revit.DB;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+using RhinoInside.Revit.External.DB.Extensions;
+using ARDB = Autodesk.Revit.DB;
+
+namespace RhinoInside.Revit.GH.Components.Import
+{
+  [ComponentVersion(introduced: "1.34")]
+  public class Link3DM : LinkFileComponent
+  {
+    public override Guid ComponentGuid => new Guid("A4D8F1B6-5E9F-7B8E-D4A7-9C1F3D5E6A7B");
+#if REVIT_2022
+    public override GH_Exposure Exposure => GH_Exposure.tertiary;
+#else
+    public override GH_Exposure Exposure => GH_Exposure.hidden;
+#endif
+    protected override string IconTag => string.Empty;
+
+    public Link3DM() : base
+    (
+      name: "Link 3DM",
+      nickname: "Link3DM",
+      description: "Link a Rhino 3DM file to the current Revit document",
+      category: "Revit",
+      subCategory: "Insert"
+    )
+    { }
+
+    protected override string[] SupportedExtensions => new[] { ".3dm" };
+    protected override string FileFilter => "Rhino 3D Model (*.3dm)|*.3dm";
+
+    protected override ParamDefinition[] Inputs => inputs;
+    static readonly ParamDefinition[] inputs =
+    {
+      new ParamDefinition
+      (
+        new Parameters.Document()
+        {
+          Name = "Document",
+          NickName = "DOC",
+          Description = "Target document for linking the 3DM file",
+          Optional = true
+        }, ParamRelevance.Occasional
+      ),
+      new ParamDefinition
+      (
+        new Param_FilePath
+        {
+          Name = "Path",
+          NickName = "P",
+          Description = "Absolute path to the 3DM file",
+          FileFilter = "Rhino 3D Model (*.3dm)|*.3dm"
+        }
+      ),
+      new ParamDefinition
+      (
+        new Parameters.Level()
+        {
+          Name = "Level",
+          NickName = "L",
+          Description = "Level to place the 3DM link"
+        }, ParamRelevance.Primary
+      )
+    };
+
+    protected override ParamDefinition[] Outputs => outputs;
+    static readonly ParamDefinition[] outputs =
+    {
+      new ParamDefinition
+      (
+        new Parameters.Element()
+        {
+          Name = _Output_,
+          NickName = _Output_.Substring(0, 1),
+          Description = $"Output {_Output_}",
+          Access = GH_ParamAccess.item
+        }
+      )
+    };
+
+    const string _Output_ = "Link";
+
+    protected override void TrySolveInstance(IGH_DataAccess DA)
+    {
+      if (!Parameters.Document.TryGetDocumentOrCurrent(this, DA, "Document", out var doc) || !doc.IsValid) return;
+
+      ReconstructElement<ARDB.ImportInstance>
+      (
+        doc.Value, _Output_, importInstance =>
+        {
+          // Input
+          if (!Params.GetData(DA, "Path", out string path)) return null;
+          if (!Params.GetData(DA, "Level", out Types.Level level)) return null;
+
+          // Validate file
+          ValidateFile(path);
+
+          // Compute
+          importInstance = Reconstruct(importInstance, doc.Value, path, doc.Value.ActiveView, level.Value);
+
+          DA.SetData(_Output_, importInstance);
+          return importInstance;
+        }
+      );
+    }
+
+    ARDB.ImportInstance Reconstruct
+    (
+      ARDB.ImportInstance importInstance,
+      ARDB.Document doc,
+      string path,
+      ARDB.View view,
+      ARDB.Level level
+    )
+    {
+      if (!Reuse(importInstance, doc, path, level))
+      {
+        if (importInstance != null && importInstance.IsValidObject)
+          doc.Delete(importInstance.Id);
+
+        var options = new ARDB.ImportOptions3DM();
+        importInstance = Create(doc, path, view, options, level);
+      }
+
+      return importInstance;
+    }
+  }
+}

--- a/src/RhinoInside.Revit.GH/Components/Import/Link3DM.cs
+++ b/src/RhinoInside.Revit.GH/Components/Import/Link3DM.cs
@@ -85,7 +85,7 @@ namespace RhinoInside.Revit.GH.Components.Import
     protected override void TrySolveInstance(IGH_DataAccess DA)
     {
       if (!Parameters.Document.TryGetDocumentOrCurrent(this, DA, "Document", out var doc) || !doc.IsValid) return;
-
+      #if REVIT_2022
       ReconstructElement<ARDB.ImportInstance>
       (
         doc.Value, _Output_, importInstance =>
@@ -104,7 +104,10 @@ namespace RhinoInside.Revit.GH.Components.Import
           return importInstance;
         }
       );
+#endif
     }
+
+#if REVIT_2022
 
     ARDB.ImportInstance Reconstruct
     (
@@ -126,5 +129,6 @@ namespace RhinoInside.Revit.GH.Components.Import
 
       return importInstance;
     }
+#endif
   }
 }

--- a/src/RhinoInside.Revit.GH/Components/Import/LinkCAD.cs
+++ b/src/RhinoInside.Revit.GH/Components/Import/LinkCAD.cs
@@ -1,0 +1,126 @@
+using System;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+using Rhino.Collections;
+using RhinoInside.Revit.External.DB.Extensions;
+using ARDB = Autodesk.Revit.DB;
+
+namespace RhinoInside.Revit.GH.Components.Import
+{
+  [ComponentVersion(introduced: "1.34")]
+  public class LinkCAD : LinkFileComponent
+  {
+    public override Guid ComponentGuid => new Guid("E2B7D9F5-3F8D-6A6E-F2C5-7E9D1B3C4E5F");
+    public override GH_Exposure Exposure => GH_Exposure.tertiary;
+    protected override string IconTag => string.Empty;
+
+    public LinkCAD() : base
+    (
+      name: "Link CAD",
+      nickname: "LinkCAD",
+      description: "Link a CAD file (DWG, DXF, DGN) to the current Revit document",
+      category: "Revit",
+      subCategory: "Insert"
+    )
+    { }
+
+    protected override string[] SupportedExtensions => new[] { ".dwg", ".dxf", ".dgn" };
+    protected override string FileFilter => "CAD Files (*.dwg, *.dxf, *.dgn)|*.dwg;*.dxf;*.dgn";
+
+    protected override ParamDefinition[] Inputs => inputs;
+    static readonly ParamDefinition[] inputs =
+    {
+      new ParamDefinition
+      (
+        new Parameters.Document()
+        {
+          Name = "Document",
+          NickName = "DOC",
+          Description = "Target document for linking the CAD file",
+          Optional = true
+        }, ParamRelevance.Occasional
+      ),
+      new ParamDefinition
+      (
+        new Param_FilePath
+        {
+          Name = "Path",
+          NickName = "P",
+          Description = "Absolute path to the CAD file",
+          FileFilter = "CAD Files (*.dwg, *.dxf, *.dgn)|*.dwg;*.dxf;*.dgn"
+        }
+      ),
+      new ParamDefinition
+      (
+        new Parameters.Level()
+        {
+          Name = "Level",
+          NickName = "L",
+          Description = "Level to place the CAD link"
+        }, ParamRelevance.Primary
+      )
+    };
+
+    protected override ParamDefinition[] Outputs => outputs;
+    static readonly ParamDefinition[] outputs =
+    {
+      new ParamDefinition
+      (
+        new Parameters.Element()
+        {
+          Name = _Output_,
+          NickName = _Output_.Substring(0, 1),
+          Description = $"Output {_Output_}",
+          Access = GH_ParamAccess.item
+        }
+      )
+    };
+
+    const string _Output_ = "Link";
+
+    protected override void TrySolveInstance(IGH_DataAccess DA)
+    {
+      if (!Parameters.Document.TryGetDocumentOrCurrent(this, DA, "Document", out var doc) || !doc.IsValid) return;
+
+      ReconstructElement<ARDB.ImportInstance>
+      (
+        doc.Value, _Output_, importInstance =>
+        {
+          // Input
+          if (!Params.GetData(DA, "Path", out string path)) return null;
+          if (!Params.GetData(DA, "Level", out Types.Level level)) return null;
+
+          // Validate file
+          ValidateFile(path);
+
+          // Compute
+          importInstance = Reconstruct(importInstance, doc.Value, path, doc.Value.ActiveView, level.Value);
+
+          DA.SetData(_Output_, importInstance);
+          return importInstance;
+        }
+      );
+    }
+
+    ARDB.ImportInstance Reconstruct
+    (
+      ARDB.ImportInstance importInstance,
+      ARDB.Document doc,
+      string path,
+      ARDB.View view,
+      ARDB.Level level
+    )
+    {
+      if (!Reuse(importInstance, doc, path, level))
+      {
+        if (importInstance != null && importInstance.IsValidObject)
+          doc.Delete(importInstance.Id);
+
+        var options = new ARDB.DWGImportOptions();
+        importInstance = Create(doc, path, view, options, level);
+      }
+
+      return importInstance;
+    }
+  }
+}

--- a/src/RhinoInside.Revit.GH/Components/Import/LinkFileComponent.cs
+++ b/src/RhinoInside.Revit.GH/Components/Import/LinkFileComponent.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using System.Linq;
+using Grasshopper.Kernel;
+using ARDB = Autodesk.Revit.DB;
+
+namespace RhinoInside.Revit.GH.Components.Import
+{
+  public abstract class LinkFileComponent : ElementTrackerComponent
+  {
+    protected LinkFileComponent(string name, string nickname, string description, string category, string subCategory)
+      : base(name, nickname, description, category, subCategory)
+    { }
+
+    protected abstract string[] SupportedExtensions { get; }
+
+    protected abstract string FileFilter { get; }
+
+    protected void ValidateFile(string path)
+    {
+      if (!File.Exists(path))
+        throw new Exceptions.RuntimeArgumentException("Path", $"File does not exist: {path}");
+
+      var extension = Path.GetExtension(path).ToLowerInvariant();
+      if (string.IsNullOrWhiteSpace(extension) ||
+          !SupportedExtensions.Any(ext => string.Equals(ext, extension, StringComparison.OrdinalIgnoreCase)))
+      {
+        var supportedList = string.Join(", ", SupportedExtensions);
+        throw new Exceptions.RuntimeArgumentException(
+            nameof(path),
+            $"File must have one of these extensions: {supportedList}. Got: {extension ?? "none"}"
+        );
+      }
+    }
+
+    protected bool Reuse(ARDB.ImportInstance importInstance, ARDB.Document doc, string filePath, ARDB.Level level)
+    {
+      if (importInstance is null) return false;
+      if (!importInstance.IsValidObject) return false;
+
+      if (!importInstance.IsLinked) return false;
+
+      if (!(doc.GetElement(importInstance.GetTypeId()) is ARDB.CADLinkType cadLinkType)) return false;
+
+      var externalFileRef = cadLinkType.GetExternalFileReference();
+      if (externalFileRef == null) return false;
+
+      var linkedPath = ARDB.ModelPathUtils.ConvertModelPathToUserVisiblePath(externalFileRef.GetPath());
+      if (string.IsNullOrEmpty(linkedPath)) return false;
+      if (!string.Equals(linkedPath, filePath, StringComparison.OrdinalIgnoreCase))
+        return false;
+
+      if (!File.Exists(linkedPath))
+        return false;
+
+      var levelId = importInstance.get_Parameter(ARDB.BuiltInParameter.IMPORT_BASE_LEVEL).AsElementId();
+      if (levelId == null || levelId == ARDB.ElementId.InvalidElementId)
+        return false;
+
+      if (levelId != level.Id)
+      {
+        importInstance.get_Parameter(ARDB.BuiltInParameter.IMPORT_BASE_LEVEL).Set(level.Id);
+        return true;
+      }
+
+      return true;
+    }
+
+    protected ARDB.ImportInstance Create(
+      ARDB.Document doc,
+      string path,
+      ARDB.View view,
+      ARDB.BaseImportOptions options,
+      ARDB.Level level)
+    {
+        ARDB.ElementId linkId = ARDB.ElementId.InvalidElementId;
+        if (SupportedExtensions.Contains(".3dm") && options is ARDB.ImportOptions3DM options3dm)
+            linkId = doc.Link(path, options3dm, view);
+            
+        else if (SupportedExtensions.Contains(".obj") && options is ARDB.OBJImportOptions optionsObj)
+            linkId = doc.Link(path, optionsObj, view);
+            
+        else if ((SupportedExtensions.Contains(".dwg") ||
+                  SupportedExtensions.Contains(".dxf")) && options is ARDB.DWGImportOptions optionsDwg)
+        {
+          if (!doc.Link(path, optionsDwg, view, out linkId))
+            throw new Exceptions.RuntimeException($"Failed to link file: {path}");
+        }
+            
+        else
+            throw new Exceptions.RuntimeException($"Unsupported file extension or import options type for: {path}");
+
+
+      // Get the import instance
+      if (!(doc.GetElement(linkId) is ARDB.ImportInstance importInstance))
+        throw new Exceptions.RuntimeException($"Failed to get import instance for link");
+
+      importInstance.get_Parameter(ARDB.BuiltInParameter.IMPORT_BASE_LEVEL).Set(level.Id);
+
+      return importInstance;
+    }
+
+    protected static readonly ARDB.BuiltInParameter[] ExcludeUniqueProperties = { };
+  }
+}

--- a/src/RhinoInside.Revit.GH/Components/Import/LinkFileComponent.cs
+++ b/src/RhinoInside.Revit.GH/Components/Import/LinkFileComponent.cs
@@ -74,22 +74,21 @@ namespace RhinoInside.Revit.GH.Components.Import
       ARDB.Level level)
     {
         ARDB.ElementId linkId = ARDB.ElementId.InvalidElementId;
+
+#if REVIT_2023
         if (SupportedExtensions.Contains(".3dm") && options is ARDB.ImportOptions3DM options3dm)
-            linkId = doc.Link(path, options3dm, view);
-            
-        else if (SupportedExtensions.Contains(".obj") && options is ARDB.OBJImportOptions optionsObj)
-            linkId = doc.Link(path, optionsObj, view);
-            
-        else if ((SupportedExtensions.Contains(".dwg") ||
-                  SupportedExtensions.Contains(".dxf")) && options is ARDB.DWGImportOptions optionsDwg)
-        {
+              linkId = doc.Link(path, options3dm, view);
+#endif
+#if REVIT_2025
+        if (SupportedExtensions.Contains(".obj") && options is ARDB.OBJImportOptions optionsObj)
+              linkId = doc.Link(path, optionsObj, view);
+#endif
+        if ((SupportedExtensions.Contains(".dwg") || SupportedExtensions.Contains(".dxf")) && options is ARDB.DWGImportOptions optionsDwg)
           if (!doc.Link(path, optionsDwg, view, out linkId))
             throw new Exceptions.RuntimeException($"Failed to link file: {path}");
-        }
-            
-        else
-            throw new Exceptions.RuntimeException($"Unsupported file extension or import options type for: {path}");
 
+        if (linkId == ARDB.ElementId.InvalidElementId)
+            throw new Exceptions.RuntimeException($"Unsupported file extension or import options type for: {path}");
 
       // Get the import instance
       if (!(doc.GetElement(linkId) is ARDB.ImportInstance importInstance))

--- a/src/RhinoInside.Revit.GH/Components/Import/LinkIFC.cs
+++ b/src/RhinoInside.Revit.GH/Components/Import/LinkIFC.cs
@@ -1,0 +1,240 @@
+using System;
+using System.IO;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+using RhinoInside.Revit.External.DB.Extensions;
+using ARDB = Autodesk.Revit.DB;
+
+namespace RhinoInside.Revit.GH.Components.Import
+{
+  [ComponentVersion(introduced: "1.34")]
+  public class LinkIFC : ElementTrackerComponent
+  {
+    public override Guid ComponentGuid => new Guid("D1A6C8F4-2E7B-5D5C-E1A4-6F8C0A2B3C4D");
+    public override GH_Exposure Exposure => GH_Exposure.tertiary;
+    protected override string IconTag => string.Empty;
+
+    public LinkIFC() : base
+    (
+      name: "Link IFC",
+      nickname: "LinkIFC",
+      description: "Link an IFC file to the current Revit document",
+      category: "Revit",
+      subCategory: "Insert"
+    )
+    { }
+
+    protected override ParamDefinition[] Inputs => inputs;
+    static readonly ParamDefinition[] inputs =
+    {
+      new ParamDefinition
+      (
+        new Parameters.Document()
+        {
+          Name = "Document",
+          NickName = "DOC",
+          Description = "Target document for linking the IFC file",
+          Optional = true
+        }, ParamRelevance.Occasional
+      ),
+      new ParamDefinition
+      (
+        new Param_FilePath
+        {
+          Name = "Path",
+          NickName = "P",
+          Description = "Absolute path to the IFC file",
+          FileFilter = "IFC Files (*.ifc, *.ifczip)|*.ifc;*.ifczip"
+        }
+      ),
+      new ParamDefinition
+      (
+        new Param_GenericObject
+        {
+          Name = "Options",
+          NickName = "O",
+          Description = "IFC import options (optional, controls how IFC is converted to RVT before linking)",
+          Optional = true
+        }, ParamRelevance.Primary
+      )
+    };
+
+    protected override ParamDefinition[] Outputs => outputs;
+    static readonly ParamDefinition[] outputs =
+    {
+      new ParamDefinition
+      (
+        new Parameters.Element()
+        {
+          Name = _Output_,
+          NickName = _Output_.Substring(0, 1),
+          Description = $"Output {_Output_}",
+          Access = GH_ParamAccess.item
+        }
+      )
+    };
+
+    const string _Output_ = "Link";
+
+    protected override void TrySolveInstance(IGH_DataAccess DA)
+    {
+      if (!Parameters.Document.TryGetDocumentOrCurrent(this, DA, "Document", out var doc) || !doc.IsValid) return;
+
+      ReconstructElement<ARDB.RevitLinkInstance>
+      (
+        doc.Value, _Output_, linkInstance =>
+        {
+          // Input
+          if (!Params.GetData(DA, "Path", out string path)) return null;
+          Params.TryGetData(DA, "Options", out ARDB.IFC.IFCImportOptions options);
+
+          // Validations
+          if (!File.Exists(path))
+            throw new Exceptions.RuntimeArgumentException("Path", $"IFC file does not exist: {path}");
+
+          var extension = Path.GetExtension(path).ToLowerInvariant();
+          if (extension != ".ifc" && extension != ".ifczip")
+            throw new Exceptions.RuntimeArgumentException("Path", $"File must be an IFC file (.ifc or .ifczip): {path}");
+
+          // Compute
+          linkInstance = Reconstruct(linkInstance, doc.Value, path, options);
+
+          DA.SetData(_Output_, linkInstance);
+          return linkInstance;
+        }
+      );
+    }
+
+    bool Reuse(ARDB.RevitLinkInstance linkInstance, ARDB.Document doc, string ifcPath)
+    {
+      if (linkInstance is null) return false;
+
+      // Check if the link instance is still valid
+      if (!linkInstance.IsValidObject) return false;
+
+      // Get the link type
+      if (!(doc.GetElement(linkInstance.GetTypeId()) is ARDB.RevitLinkType linkType)) return false;
+
+      // Get the external file reference to access the linked file path
+      var externalFileRef = linkType.GetExternalFileReference();
+      if (externalFileRef == null) return false;
+
+      // Get the path to the linked RVT file
+      var linkedRvtPath = ARDB.ModelPathUtils.ConvertModelPathToUserVisiblePath(externalFileRef.GetPath());
+      if (string.IsNullOrEmpty(linkedRvtPath)) return false;
+
+      // Verify the linked RVT file still exists
+      if (!File.Exists(linkedRvtPath))
+        return false;
+
+      // Strategy: Store the original IFC path in the link type's parameter or check by timestamp
+      // Since we can't easily get the original IFC path, we'll compare by:
+      // 1. File name (without extension)
+      // 2. File modification time (if the IFC file changed, we should recreate)
+
+      var ifcFileName = Path.GetFileNameWithoutExtension(ifcPath);
+
+      // Check if the link name contains the IFC file name
+      if (!linkType.Name.Contains(ifcFileName))
+        return false;
+
+      // Get the modification time of the current IFC file
+      var ifcModifiedTime = File.GetLastWriteTimeUtc(ifcPath);
+
+      // Get the creation time of the linked RVT file (when we converted it)
+      var rvtCreationTime = File.GetCreationTimeUtc(linkedRvtPath);
+
+      // If the IFC file was modified after we created the RVT link, we need to recreate
+      if (ifcModifiedTime > rvtCreationTime)
+        return false;
+
+      // If we reach here, the link can be reused
+      return true;
+    }
+
+    ARDB.RevitLinkInstance Create(ARDB.Document doc, string path, ARDB.IFC.IFCImportOptions options)
+    {
+      var app = Revit.ActiveUIApplication.Application;
+
+      // Generate a unique temporary path for the RVT file
+      var tempFileName = $"{Path.GetFileNameWithoutExtension(path)}_IFC_{Guid.NewGuid():N}.rvt";
+      var tempPath = Path.Combine(Path.GetTempPath(), tempFileName);
+
+      ARDB.Document tempDoc = null;
+
+      try
+      {
+        if (File.Exists(tempPath))
+          File.Delete(tempPath);
+
+        // Create default options if not provided
+        if (options == null)
+          options = new ARDB.IFC.IFCImportOptions();
+
+        // Convert IFC to RVT using OpenIFCDocument
+        tempDoc = app.OpenIFCDocument(path, options);
+
+        if (tempDoc == null || !tempDoc.IsValidObject)
+          throw new Exceptions.RuntimeException($"Failed to open IFC file: {path}");
+
+        tempDoc.SaveAs(tempPath);
+        tempDoc.Close(false);
+
+        // Create RevitLinkType
+        var linkOptions = new ARDB.RevitLinkOptions(false);
+        var linkLoadResult = ARDB.RevitLinkType.CreateFromIFC(doc, path, tempPath, false, linkOptions);
+
+        if (linkLoadResult.ElementId == ARDB.ElementId.InvalidElementId)
+          throw new Exceptions.RuntimeException($"Failed to create link from IFC file: {path}");
+
+        // Create link instance
+        var linkInstance = ARDB.RevitLinkInstance.Create(doc, linkLoadResult.ElementId);
+
+        if (linkInstance == null)
+          throw new Exceptions.RuntimeException($"Failed to create link instance from link type");
+
+        return linkInstance;
+      }
+      catch (Exception ex)
+      {
+        if (tempDoc != null && tempDoc.IsValidObject)
+          tempDoc.Close(false);
+
+        if (File.Exists(tempPath))
+          File.Delete(tempPath);
+
+        throw new Exceptions.RuntimeException($"Error creating IFC link: {ex.Message}");
+      }
+    }
+
+    ARDB.RevitLinkInstance Reconstruct
+    (
+      ARDB.RevitLinkInstance linkInstance,
+      ARDB.Document doc,
+      string path,
+      ARDB.IFC.IFCImportOptions options
+    )
+    {
+      if (!Reuse(linkInstance, doc, path))
+      {
+        if (linkInstance != null && linkInstance.IsValidObject)
+        {
+          var linkTypeId = linkInstance.GetTypeId();
+          doc.Delete(linkInstance.Id);
+
+          if (linkTypeId != ARDB.ElementId.InvalidElementId)
+          {
+            if (doc.GetElement(linkTypeId) is ARDB.RevitLinkType linkType && linkType.IsValidObject)
+            {
+              doc.Delete(linkTypeId);
+            }
+          }
+        }
+
+        linkInstance = Create(doc, path, options);
+      }
+
+      return linkInstance;
+    }
+  }
+}

--- a/src/RhinoInside.Revit.GH/Components/Import/LinkOBJ.cs
+++ b/src/RhinoInside.Revit.GH/Components/Import/LinkOBJ.cs
@@ -1,0 +1,125 @@
+using System;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+using RhinoInside.Revit.External.DB.Extensions;
+using ARDB = Autodesk.Revit.DB;
+
+namespace RhinoInside.Revit.GH.Components.Import
+{
+  [ComponentVersion(introduced: "1.34")]
+  public class LinkOBJ : LinkFileComponent
+  {
+    public override Guid ComponentGuid => new Guid("B5E9F2C7-6F0E-8C9F-E5B8-0D2F4E6F7C8D");
+    public override GH_Exposure Exposure => GH_Exposure.tertiary;
+    protected override string IconTag => string.Empty;
+
+    public LinkOBJ() : base
+    (
+      name: "Link OBJ",
+      nickname: "LinkOBJ",
+      description: "Link an OBJ file to the current Revit document",
+      category: "Revit",
+      subCategory: "Insert"
+    )
+    { }
+
+    protected override string[] SupportedExtensions => new[] { ".obj" };
+    protected override string FileFilter => "Wavefront OBJ (*.obj)|*.obj";
+
+    protected override ParamDefinition[] Inputs => inputs;
+    static readonly ParamDefinition[] inputs =
+    {
+      new ParamDefinition
+      (
+        new Parameters.Document()
+        {
+          Name = "Document",
+          NickName = "DOC",
+          Description = "Target document for linking the OBJ file",
+          Optional = true
+        }, ParamRelevance.Occasional
+      ),
+      new ParamDefinition
+      (
+        new Param_FilePath
+        {
+          Name = "Path",
+          NickName = "P",
+          Description = "Absolute path to the OBJ file",
+          FileFilter = "Wavefront OBJ (*.obj)|*.obj"
+        }
+      ),
+      new ParamDefinition
+      (
+        new Parameters.Level()
+        {
+          Name = "Level",
+          NickName = "L",
+          Description = "Level to place the OBJ link"
+        }, ParamRelevance.Primary
+      )
+    };
+
+    protected override ParamDefinition[] Outputs => outputs;
+    static readonly ParamDefinition[] outputs =
+    {
+      new ParamDefinition
+      (
+        new Parameters.Element()
+        {
+          Name = _Output_,
+          NickName = _Output_.Substring(0, 1),
+          Description = $"Output {_Output_}",
+          Access = GH_ParamAccess.item
+        }
+      )
+    };
+
+    const string _Output_ = "Link";
+
+    protected override void TrySolveInstance(IGH_DataAccess DA)
+    {
+      if (!Parameters.Document.TryGetDocumentOrCurrent(this, DA, "Document", out var doc) || !doc.IsValid) return;
+
+      ReconstructElement<ARDB.ImportInstance>
+      (
+        doc.Value, _Output_, importInstance =>
+        {
+          // Input
+          if (!Params.GetData(DA, "Path", out string path)) return null;
+          if (!Params.GetData(DA, "Level", out Types.Level level)) return null;
+
+          // Validate file
+          ValidateFile(path);
+
+          // Compute
+          importInstance = Reconstruct(importInstance, doc.Value, path, doc.Value.ActiveView, level.Value);
+
+          DA.SetData(_Output_, importInstance);
+          return importInstance;
+        }
+      );
+    }
+
+    ARDB.ImportInstance Reconstruct
+    (
+      ARDB.ImportInstance importInstance,
+      ARDB.Document doc,
+      string path,
+      ARDB.View view,
+      ARDB.Level level
+    )
+    {
+      if (!Reuse(importInstance, doc, path, level))
+      {
+        if (importInstance != null && importInstance.IsValidObject)
+          doc.Delete(importInstance.Id);
+
+        var options = new ARDB.OBJImportOptions();
+        importInstance = Create(doc, path, view, options, level);
+      }
+
+      return importInstance;
+    }
+  }
+}

--- a/src/RhinoInside.Revit.GH/Components/Import/LinkOBJ.cs
+++ b/src/RhinoInside.Revit.GH/Components/Import/LinkOBJ.cs
@@ -10,7 +10,11 @@ namespace RhinoInside.Revit.GH.Components.Import
   public class LinkOBJ : LinkFileComponent
   {
     public override Guid ComponentGuid => new Guid("B5E9F2C7-6F0E-8C9F-E5B8-0D2F4E6F7C8D");
+#if REVIT_2025
     public override GH_Exposure Exposure => GH_Exposure.tertiary;
+#else
+    public override GH_Exposure Exposure => GH_Exposure.hidden;
+#endif
     protected override string IconTag => string.Empty;
 
     public LinkOBJ() : base
@@ -77,10 +81,11 @@ namespace RhinoInside.Revit.GH.Components.Import
 
     const string _Output_ = "Link";
 
+
     protected override void TrySolveInstance(IGH_DataAccess DA)
     {
       if (!Parameters.Document.TryGetDocumentOrCurrent(this, DA, "Document", out var doc) || !doc.IsValid) return;
-
+      #if REVIT_2025
       ReconstructElement<ARDB.ImportInstance>
       (
         doc.Value, _Output_, importInstance =>
@@ -99,8 +104,10 @@ namespace RhinoInside.Revit.GH.Components.Import
           return importInstance;
         }
       );
+#endif
     }
 
+#if REVIT_2025
     ARDB.ImportInstance Reconstruct
     (
       ARDB.ImportInstance importInstance,
@@ -121,5 +128,6 @@ namespace RhinoInside.Revit.GH.Components.Import
 
       return importInstance;
     }
+#endif
   }
 }

--- a/src/RhinoInside.Revit.GH/Components/Import/LinkRevit.cs
+++ b/src/RhinoInside.Revit.GH/Components/Import/LinkRevit.cs
@@ -1,0 +1,187 @@
+using System;
+using System.IO;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+using RhinoInside.Revit.External.DB.Extensions;
+using ARDB = Autodesk.Revit.DB;
+
+namespace RhinoInside.Revit.GH.Components.Import
+{
+  [ComponentVersion(introduced: "1.34")]
+  public class LinkRevit : ElementTrackerComponent
+  {
+    public override Guid ComponentGuid => new Guid("F3C8E0A6-4E9E-7A7F-E3C6-8A0E2C4D5F6E");
+    public override GH_Exposure Exposure => GH_Exposure.tertiary;
+    protected override string IconTag => string.Empty;
+
+    public LinkRevit() : base
+    (
+      name: "Link Revit",
+      nickname: "LinkRVT",
+      description: "Link a Revit file (RVT, RFA) to the current Revit document",
+      category: "Revit",
+      subCategory: "Insert"
+    )
+    { }
+
+    protected override ParamDefinition[] Inputs => inputs;
+    static readonly ParamDefinition[] inputs =
+    {
+      new ParamDefinition
+      (
+        new Parameters.Document()
+        {
+          Name = "Document",
+          NickName = "DOC",
+          Description = "Target document for linking the Revit file",
+          Optional = true
+        }, ParamRelevance.Occasional
+      ),
+      new ParamDefinition
+      (
+        new Param_FilePath
+        {
+          Name = "Path",
+          NickName = "P",
+          Description = "Absolute path to the Revit file",
+          FileFilter = "Revit Files (*.rvt, *.rfa)|*.rvt;*.rfa"
+        }
+      ),
+      new ParamDefinition
+      (
+        new Param_Boolean
+        {
+          Name = "Absolute",
+          NickName = "A",
+          Description = "Use absolute path (true) or relative path (false)",
+          Optional = true
+        }, ParamRelevance.Secondary
+      )
+    };
+
+    protected override ParamDefinition[] Outputs => outputs;
+    static readonly ParamDefinition[] outputs =
+    {
+      new ParamDefinition
+      (
+        new Parameters.Element()
+        {
+          Name = _Output_,
+          NickName = _Output_.Substring(0, 1),
+          Description = $"Output {_Output_}",
+          Access = GH_ParamAccess.item
+        }
+      )
+    };
+
+    const string _Output_ = "Link";
+
+    protected override void TrySolveInstance(IGH_DataAccess DA)
+    {
+      if (!Parameters.Document.TryGetDocumentOrCurrent(this, DA, "Document", out var doc) || !doc.IsValid) return;
+
+      ReconstructElement<ARDB.RevitLinkInstance>
+      (
+        doc.Value, _Output_, linkInstance =>
+        {
+          // Input
+          if (!Params.GetData(DA, "Path", out string path)) return null;
+          Params.TryGetData(DA, "Absolute", out bool? absolute);
+
+          // Validations
+          if (!File.Exists(path))
+            throw new Exceptions.RuntimeArgumentException("Path", $"Revit file does not exist: {path}");
+
+          var extension = Path.GetExtension(path).ToLowerInvariant();
+          if (extension != ".rvt" && extension != ".rfa")
+            throw new Exceptions.RuntimeArgumentException("Path", $"File must be a Revit file (.rvt or .rfa): {path}");
+          
+          // Compute
+          linkInstance = Reconstruct(linkInstance, doc.Value, path, absolute ?? false);
+
+          DA.SetData(_Output_, linkInstance);
+          return linkInstance;
+        }
+      );
+    }
+
+    bool Reuse(ARDB.RevitLinkInstance linkInstance, ARDB.Document doc, string rvtPath)
+    {
+      if (linkInstance is null) return false;
+      if (!linkInstance.IsValidObject) return false;
+
+      if (!(doc.GetElement(linkInstance.GetTypeId()) is ARDB.RevitLinkType linkType)) return false;
+
+      var externalFileRef = linkType.GetExternalFileReference();
+      if (externalFileRef == null) return false;
+
+      var linkedPath = ARDB.ModelPathUtils.ConvertModelPathToUserVisiblePath(externalFileRef.GetPath());
+      if (string.IsNullOrEmpty(linkedPath)) return false;
+
+      var normalizedLinkedPath = Path.GetFullPath(linkedPath);
+      var normalizedInputPath = Path.GetFullPath(rvtPath);
+
+      if (!string.Equals(normalizedLinkedPath, normalizedInputPath, StringComparison.OrdinalIgnoreCase))
+        return false;
+
+      if (!File.Exists(linkedPath))
+        return false;
+
+      var rvtModifiedTime = File.GetLastWriteTimeUtc(rvtPath);
+      var linkStatus = linkType.GetLinkedFileStatus();
+
+      if (linkStatus != ARDB.LinkedFileStatus.Loaded)
+        return false;
+
+      return true;
+    }
+
+    ARDB.RevitLinkInstance Create(ARDB.Document doc, string path, bool absolute)
+    {
+      var modelPath = ARDB.ModelPathUtils.ConvertUserVisiblePathToModelPath(path);
+
+      var linkOptions = new ARDB.RevitLinkOptions(!absolute);
+      var linkLoadResult = ARDB.RevitLinkType.Create(doc, modelPath, linkOptions);
+
+      if (linkLoadResult.ElementId == ARDB.ElementId.InvalidElementId)
+        throw new Exceptions.RuntimeException($"Failed to create Revit link from file: {path}");
+
+      var linkInstance = ARDB.RevitLinkInstance.Create(doc, linkLoadResult.ElementId);
+
+      if (linkInstance == null)
+        throw new Exceptions.RuntimeException($"Failed to create link instance for Revit link");
+
+      return linkInstance;
+    }
+
+    ARDB.RevitLinkInstance Reconstruct
+    (
+      ARDB.RevitLinkInstance linkInstance,
+      ARDB.Document doc,
+      string path,
+      bool absolute
+    )
+    {
+      if (!Reuse(linkInstance, doc, path))
+      {
+        if (linkInstance != null && linkInstance.IsValidObject)
+        {
+          var linkTypeId = linkInstance.GetTypeId();
+          doc.Delete(linkInstance.Id);
+
+          if (linkTypeId != ARDB.ElementId.InvalidElementId)
+          {
+            if (doc.GetElement(linkTypeId) is ARDB.RevitLinkType linkType && linkType.IsValidObject)
+            {
+              doc.Delete(linkTypeId);
+            }
+          }
+        }
+
+        linkInstance = Create(doc, path, absolute);
+      }
+
+      return linkInstance;
+    }
+  }
+}

--- a/src/RhinoInside.Revit.GH/Components/Import/OpenIFC.cs
+++ b/src/RhinoInside.Revit.GH/Components/Import/OpenIFC.cs
@@ -1,0 +1,121 @@
+using System;
+using System.IO;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+using ARDB = Autodesk.Revit.DB;
+
+namespace RhinoInside.Revit.GH.Components.Import
+{
+  [ComponentVersion(introduced: "1.34")]
+  public class OpenIFC : ZuiComponent
+  {
+    public override Guid ComponentGuid => new Guid("CA8912CE-19A9-404C-95EE-C758A5C7E4C9");
+    public override GH_Exposure Exposure => GH_Exposure.tertiary;
+    protected override string IconTag => string.Empty;
+
+    public OpenIFC() : base
+    (
+      name: "Open IFC",
+      nickname: "OpenIFC",
+      description: "Open an IFC file as a new Revit document (does not link to current document)",
+      category: "Revit",
+      subCategory: "Insert"
+    )
+    { }
+
+    protected override ParamDefinition[] Inputs => inputs;
+    static readonly ParamDefinition[] inputs =
+    {
+      new ParamDefinition
+      (
+        new Param_FilePath
+        {
+          Name = "Path",
+          NickName = "P",
+          Description = "Absolute path to the IFC file",
+          FileFilter = "IFC Files (*.ifc, *.ifczip)|*.ifc;*.ifczip"
+        }
+      ),
+      new ParamDefinition
+      (
+        new Param_GenericObject
+        {
+          Name = "Options",
+          NickName = "O",
+          Description = "IFC import options (optional, Action will be forced to 'Open')",
+          Optional = true
+        }, ParamRelevance.Primary
+      )
+    };
+
+    protected override ParamDefinition[] Outputs => outputs;
+    static readonly ParamDefinition[] outputs =
+    {
+      new ParamDefinition
+      (
+        new Parameters.Document()
+        {
+          Name = _Output_,
+          NickName = _Output_.Substring(0, 1),
+          Description = $"Output {_Output_}",
+          Access = GH_ParamAccess.item
+        }
+      )
+    };
+
+    const string _Output_ = "Document";
+
+    protected override void TrySolveInstance(IGH_DataAccess DA)
+    {
+      // Input
+      if (!Params.GetData(DA, "Path", out string path)) return;
+      Params.TryGetData(DA, "Options", out ARDB.IFC.IFCImportOptions options);
+
+      // Validations
+      if (!File.Exists(path))
+        throw new Exceptions.RuntimeArgumentException("Path", $"IFC file does not exist: {path}");
+
+      var extension = Path.GetExtension(path).ToLowerInvariant();
+      if (extension != ".ifc" && extension != ".ifczip")
+        throw new Exceptions.RuntimeArgumentException("Path", $"File must be an IFC file (.ifc or .ifczip): {path}");
+
+      // Compute
+      var ifcDocument = OpenIFCDocument(path, options);
+
+      DA.SetData(_Output_, ifcDocument);
+    }
+
+    ARDB.Document OpenIFCDocument(string path, ARDB.IFC.IFCImportOptions options)
+    {
+      if (options == null)
+        options = new ARDB.IFC.IFCImportOptions();
+
+      if (options.Action != ARDB.IFC.IFCImportAction.Open)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
+          $"IFC Import Action is set to '{options.Action}'. OpenIFCDocument only supports 'Open' action. " +
+          "Setting Action to Open.");
+        options.Action = ARDB.IFC.IFCImportAction.Open;
+      }
+
+      if (options.Intent != ARDB.IFC.IFCImportIntent.Parametric)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
+          $"IFC Import Intent is set to '{options.Intent}'. OpenIFCDocument works best with 'Parametric' intent. " +
+          "Setting Intent to Parametric.");
+        options.Intent = ARDB.IFC.IFCImportIntent.Parametric;
+
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Remark,
+          "For Link action or Reference intent, use the 'Link IFC' component instead.");
+      }
+
+      var app = Revit.ActiveUIApplication.Application;
+      var ifcDocument = app.OpenIFCDocument(path, options);
+
+      if (ifcDocument == null || !ifcDocument.IsValidObject)
+        throw new Exceptions.RuntimeException($"Failed to open IFC file: {path}");
+
+      return ifcDocument;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
  This PR introduces a comprehensive set of file linking components for Grasshopper, allowing users to link external files (IFC,
  Revit, CAD, 3DM, OBJ) into Revit documents with proper element tracking and Level-based placement control.

  ## Changes

  ### New Components
  - **LinkIFC** - Links IFC files by converting to RVT first, then creating a RevitLinkType
  - **LinkRevit** - Links Revit files (RVT, RFA) to the current document
  - **LinkCAD** - Links CAD files (DWG, DXF, DGN)
  - **Link3DM** - Links Rhino 3D Model files (Revit 2022+)
  - **LinkOBJ** - Links Wavefront OBJ files
  - **OpenIFC** - Opens IFC files as new Revit documents (not a link)

  ### Base Class
  - **LinkFileComponent** - Abstract base class providing shared functionality:
    - File validation with extension checking
    - Reuse logic with path and level comparison
    - Create logic with proper IMPORT_BASE_LEVEL parameter management
    - Common patterns across all link components

  ### Key Features
  - **Level-based placement**: All link components require a Level input for consistent placement control
  - **Element tracking**: Uses ElementTrackerComponent pattern for proper Reconstruct behavior
  - **Memory management**: RevitLinkType cleanup for Revit and IFC links to prevent memory leaks
  - **Import options support**: LinkIFC and OpenIFC accept IFCImportOptions for conversion control
  - **Path flexibility**: LinkRevit supports absolute/relative path options

  ### Technical Details
  - Components always use the active view for linking operations
  - Level changes trigger link recreation through IMPORT_BASE_LEVEL parameter comparison
  - File path changes properly, delete and recreate links (not using ReplaceElement)
  - RevitLinkInstance and RevitLinkType are both deleted when recreating Revit/IFC links
  - All components follow the standard input/output naming conventions

  ## Testing
  Manual testing performed across:
  - File path changes (triggers recreation)
  - Level changes (triggers recreation)
  - Options parameter changes for IFC components
  - Memory cleanup verification for RevitLinkType deletion

  ## Category
  Component: Insert (tertiary exposure for all components except Link3DM which is hidden pre-2022)