### PR TITLE
#1302. Fixed the AddTruss Component to update the type

### DIFF
--- a/src/RhinoInside.Revit.GH/Components/Structure/AddTruss.cs
+++ b/src/RhinoInside.Revit.GH/Components/Structure/AddTruss.cs
@@ -133,7 +133,7 @@ namespace RhinoInside.Revit.GH.Components.Structure
             );
           }
 
-          if (!Parameters.FamilySymbol.GetDataOrDefault(this, DA, "Truss", out Types.FamilySymbol type, doc, ARDB.BuiltInCategory.OST_Truss)) return null;
+          if (!Parameters.FamilySymbol.GetDataOrDefault(this, DA, "Type", out Types.FamilySymbol type, doc, ARDB.BuiltInCategory.OST_Truss)) return null;
 
           // Compute
           truss = Reconstruct(truss, doc.Value, curve, sketchPlane.Value, type.Value);


### PR DESCRIPTION
A minor typo in the type assignment logic prevented the selected Truss type from being applied, forcing all Truss elements to fall back to Revit’s default Truss type.
