### PR TITLE
Fixed `ReferenceId.ToString`.

### DIFF
--- a/src/RhinoInside.Revit.External/DB/ElementEnumerable.cs
+++ b/src/RhinoInside.Revit.External/DB/ElementEnumerable.cs
@@ -75,7 +75,7 @@ namespace RhinoInside.Revit.External.DB
     {
       if (ViewId is null)
       {
-        if (LinkId is null)
+        if (!LinkId.IsValid())
         {
           return new FilteredElementCollector(Document);
         }

--- a/src/RhinoInside.Revit.External/DB/UniqueId.cs
+++ b/src/RhinoInside.Revit.External/DB/UniqueId.cs
@@ -242,6 +242,9 @@ namespace RhinoInside.Revit.External.DB
       if (IsLinked)
       {
         var linkedDocument = (document?.GetElement(new ARDB.ElementId(Record.Id)) as ARDB.RevitLinkInstance)?.GetLinkDocument();
+        if (document is object && linkedDocument is null)
+          throw new InvalidCastException($"Failed to convert '{this}' to a persistent string.");
+
         return IsInstance ?
           $"{Record.ToString(document)}:{Element.ToString(linkedDocument)}:{Symbol.ToString(linkedDocument)}" :
           $"{Record.ToString(document)}:{Element.ToString(linkedDocument)}";

--- a/src/RhinoInside.Revit.GH/Components/Element/QueryElements.cs
+++ b/src/RhinoInside.Revit.GH/Components/Element/QueryElements.cs
@@ -187,7 +187,7 @@ namespace RhinoInside.Revit.GH.Components.Elements
       if (!Params.TryGetDataList(DA, "Categories", out IList<Types.Category> categories)) return;
       if (!Params.TryGetData(DA, "Filter", out ARDB.ElementFilter filter, x => x.IsValidObject)) return;
 
-      if (view.AssertValidModel(model))
+      if (view.AssertValidModel(model, acceptLinked: true))
       {
         if (filter?.IsEmpty() is true) return;
         var elementCollector = view.Value.CollectElements(model.ModelInstance.Id);

--- a/src/RhinoInside.Revit.GH/Components/ElementCollectorComponent.cs
+++ b/src/RhinoInside.Revit.GH/Components/ElementCollectorComponent.cs
@@ -196,11 +196,8 @@ namespace RhinoInside.Revit.GH.Components
       switch (model)
       {
         case null:
-        case Types.Document _:
-          return elements;
-
-        case Types.RevitLinkInstance _:
-          return elements.Select(x => (T) Types.Element.FromLinkElement(model.ModelInstance.Value, x));
+        case Types.Document _: return elements;
+        case Types.RevitLinkInstance instance: return elements.Select(x => (T) x.AsLinked(instance.Value));
       }
 
       return Array.Empty<T>();

--- a/src/RhinoInside.Revit.GH/Types/Element.Activator.cs
+++ b/src/RhinoInside.Revit.GH/Types/Element.Activator.cs
@@ -199,22 +199,27 @@ namespace RhinoInside.Revit.GH.Types
       return new Element(element);
     }
 
-    internal static Element FromLinkElement(ARDB.RevitLinkInstance link, Element element)
+    internal Element AsLinked(ARDB.RevitLinkInstance link)
     {
-      var linkedElementId = ERDB.ReferenceId.Parse(element.ReferenceUniqueId, element.ReferenceDocument);
-      linkedElementId = new ERDB.ReferenceId
-      (
-        new ERDB.GeometryObjectId(link.Id.ToValue(), new int[] { 0 }, ERDB.GeometryObjectType.RVTLINK, link.GetTypeId().ToValue()),
-        linkedElementId.Element
-      );
+      if (link?.GetLinkDocument()?.Equals(Document) is true)
+      {
+        var linkedElementId = ERDB.ReferenceId.Parse(ReferenceUniqueId, ReferenceDocument);
+        linkedElementId = new ERDB.ReferenceId
+        (
+          new ERDB.GeometryObjectId(link.Id.ToValue(), new int[] { 0 }, ERDB.GeometryObjectType.RVTLINK, link.GetTypeId().ToValue()),
+          linkedElementId.Element
+        );
 
-      var doc = link.Document;
-      element.ReferenceUniqueId = linkedElementId.ToString(doc);
-      element.ReferenceDocumentId = doc.GetPersistentGUID();
-      element._ReferenceDocument = doc;
-      element._ReferenceId = link.Id;
-      if(element is GraphicalElement) element.ReferenceTransform =  link.GetTransform().ToTransform();
-      return element;
+        var doc = link.Document;
+        ReferenceUniqueId = linkedElementId.ToString(doc);
+        ReferenceDocumentId = doc.GetPersistentGUID();
+        _ReferenceDocument = doc;
+        _ReferenceId = link.Id;
+        if (this is GraphicalElement) ReferenceTransform = link.GetTransform().ToTransform();
+        return this;
+      }
+
+      return null;
     }
 
     public static Element FromElementId(ARDB.Document doc, ARDB.ElementId id)
@@ -248,7 +253,7 @@ namespace RhinoInside.Revit.GH.Types
         FromElement(link.GetLinkDocument()?.GetElement(id.LinkedElementId)) is Element element
       )
       {
-        return FromLinkElement(link, element);
+        return element.AsLinked(link);
       }
 
       return default;
@@ -271,11 +276,8 @@ namespace RhinoInside.Revit.GH.Types
       switch (model)
       {
         case null:
-        case Document _:
-          return this;
-
-        case RevitLinkInstance _:
-          return Element.FromLinkElement(model.ModelInstance.Value, this);
+        case Document _: return this;
+        case RevitLinkInstance instance: return AsLinked(instance.Value);
       }
 
       return null;

--- a/src/RhinoInside.Revit.GH/Types/Reference.cs
+++ b/src/RhinoInside.Revit.GH/Types/Reference.cs
@@ -265,7 +265,7 @@ namespace RhinoInside.Revit.GH.Types
       if (element is object)
       {
         if (IsLinked && Document.IsEquivalent(element.Document))
-          return (T) Element.FromLinkElement(ReferenceDocument.GetElement(ReferenceId) as ARDB.RevitLinkInstance, element);
+          return (T) element.AsLinked(ReferenceDocument.GetElement(ReferenceId) as ARDB.RevitLinkInstance);
 
         if (element.Document is object && !ReferenceDocument.IsEquivalent(element.Document))
           throw new Exceptions.RuntimeArgumentException(nameof(element), $"Invalid Document");
@@ -291,13 +291,13 @@ namespace RhinoInside.Revit.GH.Types
       return GeometryObject.FromLinkElementId(ReferenceDocument, GetAbsoluteReference(reference).ToLinkElementId()) as GeometryElement;
     }
 
-    internal bool AssertValidModel(IGH_ModelInstance model)
+    internal bool AssertValidModel(IGH_ModelInstance model, bool acceptLinked = false)
     {
       switch (model)
       {
         case null: return false;
-        case RevitLinkInstance instance: return instance.ReferenceDocument.Equals(ReferenceDocument);
-        case ProjectDocument project: return project.Value.Equals(ReferenceDocument);
+        case Document document: return document.Value.Equals(Document);
+        case RevitLinkInstance instance: return instance.ModelDocument.Equals(Document) || (acceptLinked && instance.ReferenceDocument.Equals(ReferenceDocument));
       }
 
       throw new Exceptions.RuntimeArgumentException("Model", "Invalid Document");


### PR DESCRIPTION
When the linked document is missing.