### PR TITLE
Fix on assembly resolver.

### DIFF
--- a/src/RhinoInside.Revit/AssemblyResolver.cs
+++ b/src/RhinoInside.Revit/AssemblyResolver.cs
@@ -92,14 +92,17 @@ namespace RhinoInside.Revit
       var loadedAssembly = args.LoadedAssembly;
       if (loadedAssembly.ReflectionOnly || loadedAssembly.IsDynamic) return;
 
-#if NET10_0_OR_GREATER
+#if NET
       if (System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(loadedAssembly) == InternalContext)
         System.Resources.Extensions.ResourceManager.AssemblyLoaded(loadedAssembly);
 #endif
 
       var assemblyName = loadedAssembly.GetName();
       if (references.TryGetValue(assemblyName.Name, out var location))
-        location.Activate(loadedAssembly);
+      {
+        if (location.Name.FullName == loadedAssembly.FullName)
+          location.Activate(loadedAssembly);
+      }
     }
     #endregion
 

--- a/src/RhinoInside.Revit/System/ResourceManager.cs
+++ b/src/RhinoInside.Revit/System/ResourceManager.cs
@@ -1,4 +1,4 @@
-#if NET10_0_OR_GREATER
+#if NET
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;


### PR DESCRIPTION
When a Revit AddIn has a different version of an assembly deployed by Rhino.
Only .NET Core.